### PR TITLE
Fixed significant bug in GAC where TD error did not use bootstrapped next state

### DIFF
--- a/src/algorithms/nn/GreedyAC/GreedyAC.py
+++ b/src/algorithms/nn/GreedyAC/GreedyAC.py
@@ -52,7 +52,7 @@ class GreedyAC(BaseAgent):
             action=self.action,
             reward = reward,
             next_state=observation,
-            done_mask=False
+            done_mask=True
             )
         self.state = observation
         self.action = self.greedy_ac.sample_action(self.state)
@@ -69,7 +69,7 @@ class GreedyAC(BaseAgent):
             action=self.action,
             reward = reward,
             next_state=np.zeros(self.observations),
-            done_mask=True
+            done_mask=False
             )
         self.state = None
         self.action = None


### PR DESCRIPTION
Probably did not effect simulation experiments because the optimal policy can still be learned with gamma=0 for the lights on/lights off task