### PR TITLE
Fix: Disable wandb image logging in mock environments

### DIFF
--- a/src/main_real.py
+++ b/src/main_real.py
@@ -178,7 +178,8 @@ async def main():
         if glue.total_steps == 0:
             s, a, info = await glue.start()
             episode = chk['episode']
-            log(env, glue, wandb_run, s, a, info, is_mock_env=exp.problem.startswith("Mock"), episode=episode)
+            is_mock_env = exp.problem.startswith("Mock")
+            log(env, glue, wandb_run, s, a, info, is_mock_env=is_mock_env, episode=episode)
             interaction = Interaction(
                 o=s,
                 a=a,

--- a/src/main_real.py
+++ b/src/main_real.py
@@ -221,9 +221,9 @@ async def main():
 
             episodic_return = glue.total_reward if interaction.t else None
             episode = chk['episode']
-            log(env, glue, wandb_run, interaction.o, interaction.a, interaction.extra, is_mock_env=exp.problem.startswith("Mock"), r=interaction.r, t=interaction.t, episodic_return=episodic_return, episode=episode)
+            log(env, glue, wandb_run, interaction.o, interaction.a, interaction.extra, is_mock_env=is_mock_env, r=interaction.r, t=interaction.t, episodic_return=episodic_return, episode=episode)
 
-            if not exp.problem.startswith("Mock"):
+            if not is_mock_env:
                 img_name = save_images(env, dataset_path, images_save_keys)
                 append_csv(chk, env, glue, raw_csv_path, img_name, interaction)
 
@@ -244,7 +244,7 @@ async def main():
                 logger.debug(f'{episode} {step} {glue.total_reward} {avg_time:.4}ms {int(fps)}')
 
                 s, a, info = await glue.start()
-                log(env, glue, wandb_run, s, a, info, is_mock_env=exp.problem.startswith("Mock"))
+                log(env, glue, wandb_run, s, a, info, is_mock_env=is_mock_env)
                 interaction = Interaction(
                     o=s,
                     a=a,

--- a/src/main_real.py
+++ b/src/main_real.py
@@ -178,7 +178,7 @@ async def main():
         if glue.total_steps == 0:
             s, a, info = await glue.start()
             episode = chk['episode']
-            log(env, glue, wandb_run, s, a, info, episode=episode)
+            log(env, glue, wandb_run, s, a, info, is_mock_env=exp.problem.startswith("Mock"), episode=episode)
             interaction = Interaction(
                 o=s,
                 a=a,
@@ -220,7 +220,7 @@ async def main():
 
             episodic_return = glue.total_reward if interaction.t else None
             episode = chk['episode']
-            log(env, glue, wandb_run, interaction.o, interaction.a, interaction.extra, interaction.r, interaction.t, episodic_return, episode)
+            log(env, glue, wandb_run, interaction.o, interaction.a, interaction.extra, is_mock_env=exp.problem.startswith("Mock"), r=interaction.r, t=interaction.t, episodic_return=episodic_return, episode=episode)
 
             if not exp.problem.startswith("Mock"):
                 img_name = save_images(env, dataset_path, images_save_keys)
@@ -243,7 +243,7 @@ async def main():
                 logger.debug(f'{episode} {step} {glue.total_reward} {avg_time:.4}ms {int(fps)}')
 
                 s, a, info = await glue.start()
-                log(env, glue, wandb_run, s, a, info)
+                log(env, glue, wandb_run, s, a, info, is_mock_env=exp.problem.startswith("Mock"))
                 interaction = Interaction(
                     o=s,
                     a=a,

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -100,7 +100,7 @@ def create_annotated_image(image_data, box_data, class_id_to_label, masks_dict):
     return wandb.Image(image_data, file_type="jpg")
 
 
-def log(env, glue, wandb_run, s, a, info, r=None, t=None, episodic_return=None, episode=None):
+def log(env, glue, wandb_run, s, a, info, is_mock_env: bool, r=None, t=None, episodic_return=None, episode=None):
     expanded_info = {}
     for key, value in info.items():
         if isinstance(value, pd.DataFrame):
@@ -120,22 +120,24 @@ def log(env, glue, wandb_run, s, a, info, r=None, t=None, episodic_return=None, 
         data.update(expand("action", env.last_action))
     if hasattr(env, "time"):
         data["time"] = env.time.timestamp()
-    if hasattr(env, "image"):
-        data["raw_image"] = wandb.Image(env.image, file_type="jpg")
 
-        if hasattr(env, "detections"):
-            detections = env.detections
+    if not is_mock_env:
+        if hasattr(env, "image"):
+            data["raw_image"] = wandb.Image(env.image, file_type="jpg")
 
-            # Extract box and mask data
-            box_data, class_id_to_label = format_bounding_boxes(detections)
-            masks_dict = format_masks(detections, class_id_to_label)
+            if hasattr(env, "detections"):
+                detections = env.detections
 
-            # Get the image data to be annotated
-            image_data = env.images.get("warped", env.image) if hasattr(env, "images") else env.image
+                # Extract box and mask data
+                box_data, class_id_to_label = format_bounding_boxes(detections)
+                masks_dict = format_masks(detections, class_id_to_label)
 
-            # Create annotated image
-            if box_data or masks_dict:
-                data["image"] = create_annotated_image(image_data, box_data, class_id_to_label, masks_dict)
+                # Get the image data to be annotated
+                image_data = env.images.get("warped", env.image) if hasattr(env, "images") else env.image
+
+                # Create annotated image
+                if box_data or masks_dict:
+                    data["image"] = create_annotated_image(image_data, box_data, class_id_to_label, masks_dict)
 
     if r is not None:
         data["reward"] = r

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -100,7 +100,7 @@ def create_annotated_image(image_data, box_data, class_id_to_label, masks_dict):
     return wandb.Image(image_data, file_type="jpg")
 
 
-def log(env, glue, wandb_run, s, a, info, is_mock_env: bool, r=None, t=None, episodic_return=None, episode=None):
+def log(env, glue, wandb_run, s, a, info, is_mock_env: bool = False, r=None, t=None, episodic_return=None, episode=None):
     expanded_info = {}
     for key, value in info.items():
         if isinstance(value, pd.DataFrame):


### PR DESCRIPTION
I modified `utils.logger.log` to accept an `is_mock_env` parameter. Image logging to wandb within this function is now skipped if `is_mock_env` is true.

I updated call sites of `utils.logger.log` in `main_real.py` to pass `exp.problem.startswith("Mock")` as the value for `is_mock_env`.

This change ensures that images are not logged to wandb when you are running in a mock environment, aligning with the existing behavior for saving images to disk.