### PR TITLE
Add caching for pip dependencies in GitHub Actions workflows.

### DIFF
--- a/.github/workflows/python-test-camera-api.yml
+++ b/.github/workflows/python-test-camera-api.yml
@@ -22,7 +22,16 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.11
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('api/camera/requirements-test.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
+      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest

--- a/.github/workflows/python-test-camera2-api.yml
+++ b/.github/workflows/python-test-camera2-api.yml
@@ -22,7 +22,16 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.11
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('api/camera2/requirements-test.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
+      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest

--- a/.github/workflows/python-test-lightbar-api.yml
+++ b/.github/workflows/python-test-lightbar-api.yml
@@ -22,7 +22,16 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.11
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('api/lightbar/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
+      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest

--- a/.github/workflows/python-test-status-api.yml
+++ b/.github/workflows/python-test-status-api.yml
@@ -22,7 +22,16 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.11
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('api/status/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
+      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,7 +20,16 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.11
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
+      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest


### PR DESCRIPTION
This change introduces caching for pip dependencies in Python test workflows to speed up test execution.

The following workflows were modified:
- .github/workflows/python-test.yml
- .github/workflows/python-test-camera-api.yml
- .github/workflows/python-test-camera2-api.yml
- .github/workflows/python-test-lightbar-api.yml
- .github/workflows/python-test-status-api.yml

In each workflow:
- A caching step was added before dependency installation.
- The cache path is set to ~/.cache/pip.
- The cache key is generated based on the OS and a hash of the relevant dependency file (pyproject.toml or requirements.txt).
- Dependency installation is skipped if the cache is restored successfully.