### PR TITLE
Migrate to new rl-control-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 
 *.mp4
 wandb
+uv.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Andrew Patterson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/check_imports.py
+++ b/check_imports.py
@@ -1,0 +1,8 @@
+import numpy
+import PyExpUtils
+import ReplayTables
+import RlGlue
+import RlEvaluation
+import ml_instrument
+
+print("All imports successful!")

--- a/clusters/home.json
+++ b/clusters/home.json
@@ -1,0 +1,7 @@
+{
+    "type": "single_node",
+    "time": "2:59:00",
+    "cores": 12,
+    "mem_per_core": "4G",
+    "sequential": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     # custom minatar with jit compiled environments
     'MinAtar @ git+https://github.com/andnp/MinAtar',
     'foragerenv @ git+https://github.com/andnp/forager',
-
     'gymnasium[atari, box2d]>=1.0.0',
     'optuna',
     'ale_py',
@@ -31,14 +30,15 @@ dependencies = [
     'jax>=0.2.14',
     'dm-haiku>=0.0.4',
     'optax>=0.0.8',
-    'numpy>=1.22.0',
+    'numpy>=2.0.0',
     'PyFixedReps-andnp~=4.0',
-    'PyExpUtils-andnp~=7.0',
+    'PyExpUtils-andnp~=8.0',
     'pyrlenvs-andnp~=2.0',
-    'ReplayTables-andnp~=6.0',
-    'RlGlue-andnp~=1.0',
-    'RlEvaluation @ git+https://github.com/rlai-lab/rl-evaluation@ef3a117f7515ba74e7d6ef455e0a2b6a481531b8',
+    'ReplayTables-andnp~=8.0',
+    'RlGlue-andnp~=2.0',
+    'RlEvaluation~=1.0',
     'PyExpPlotting-andnp',
+    'ml-instrument>=0.3.1',
     'matplotlib',
     'requests>=2.32.3',
     'plantcv~=4.2.1',
@@ -51,7 +51,7 @@ dependencies = [
     'aiohttp-retry',
 ]
 
-[project.optional-dependencies]
+[dependency-groups] # Renamed section
 dev = [
     'pip',
     'ruff',

--- a/scripts/local.py
+++ b/scripts/local.py
@@ -8,13 +8,12 @@ import subprocess
 from functools import partial
 from multiprocessing.pool import Pool
 
-from PyExpUtils.runner.utils import gather_missing_indices
+from utils.results import gather_missing_indices
 import experiment.ExperimentModel as Experiment
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--runs', type=int, required=True)
 parser.add_argument('-e', type=str, nargs='+', required=True)
-parser.add_argument('--cpus', type=int, default=8)
 parser.add_argument('--entry', type=str, default='src/main.py')
 parser.add_argument('--results', type=str, default='./')
 
@@ -29,7 +28,7 @@ def count(pre, it):
 if __name__ == "__main__":
     cmdline = parser.parse_args()
 
-    pool = Pool(cmdline.cpus)
+    pool = Pool()
 
     cmds = []
     e_to_missing = gather_missing_indices(cmdline.e, cmdline.runs, loader=Experiment.load)
@@ -47,3 +46,4 @@ if __name__ == "__main__":
     for i, _ in enumerate(res):
         sys.stderr.write(f'\r{i+1}/{len(cmds)}')
     sys.stderr.write('\n')
+    pool.close()

--- a/src/algorithms/BaseAgent.py
+++ b/src/algorithms/BaseAgent.py
@@ -1,12 +1,12 @@
 from typing import Dict, Tuple
 
 import numpy as np
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
-import utils.RlGlue.agent
+from rlglue.agent import BaseAgent as Base
 
 
-class BaseAgent(utils.RlGlue.agent.BaseAgent):
+class BaseAgent(Base):
     def __init__(self, observations: Tuple[int, ...], actions: int, params: Dict, collector: Collector, seed: int):
         self.observations = observations
         self.actions = actions

--- a/src/algorithms/nn/DQN.py
+++ b/src/algorithms/nn/DQN.py
@@ -1,6 +1,6 @@
 from functools import partial
 from typing import Any, Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 from ReplayTables.ReplayBuffer import Batch
 
 from algorithms.nn.NNAgent import NNAgent
@@ -52,7 +52,7 @@ class DQN(NNAgent):
 
     # internal compiled version of the value function
     @partial(jax.jit, static_argnums=0)
-    def _values(self, state: AgentState, x: jax.Array):
+    def _values(self, state: AgentState, x: jax.Array): # type: ignore
         phi = self.phi(state.params, x).out
         return self.q(state.params, phi)
 
@@ -74,7 +74,7 @@ class DQN(NNAgent):
         self.updates += 1
 
         batch = self.buffer.sample(self.batch_size)
-        weights = self.buffer.isr_weights(batch.eid)
+        weights = self.buffer.isr_weights(batch.trans_id)
         self.state, metrics = self._computeUpdate(self.state, batch, weights)
 
         metrics = jax.device_get(metrics)

--- a/src/algorithms/nn/EQRC.py
+++ b/src/algorithms/nn/EQRC.py
@@ -1,6 +1,6 @@
 from functools import partial
 from typing import Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 from ReplayTables.interface import Batch
 
 from algorithms.nn.NNAgent import NNAgent, AgentState
@@ -33,7 +33,7 @@ class EQRC(NNAgent):
     # jit'ed internal value function approximator
     # considerable speedup, especially for larger networks (note: haiku networks are not jit'ed by default)
     @partial(jax.jit, static_argnums=0)
-    def _values(self, state: AgentState, x: jax.Array):
+    def _values(self, state: AgentState, x: jax.Array): # type: ignore
         phi = self.phi(state.params, x).out
         return self.q(state.params, phi)
 
@@ -76,7 +76,7 @@ class EQRC(NNAgent):
         decay = tree_map(
             lambda h, dh: dh - self.stepsize * self.beta * h,
             params['h'],
-            updates['h'],
+            updates['h'], # type: ignore
         )
 
         updates |= {'h': decay}

--- a/src/algorithms/tc/ESARSA.py
+++ b/src/algorithms/tc/ESARSA.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numba import njit
 from typing import Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from algorithms.tc.TCAgent import TCAgent
 from utils.checkpoint import checkpointable

--- a/src/algorithms/tc/QL.py
+++ b/src/algorithms/tc/QL.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numba import njit
 from typing import Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from algorithms.tc.TCAgent import TCAgent
 from utils.checkpoint import checkpointable

--- a/src/algorithms/tc/SoftmaxAC.py
+++ b/src/algorithms/tc/SoftmaxAC.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import njit
 from typing import Dict, Tuple
 from utils.checkpoint import checkpointable
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from algorithms.tc.TCAgent import TCAgent
 
@@ -48,8 +48,8 @@ class SoftmaxAC(TCAgent):
         self.w = np.zeros((self.rep.features()), dtype=np.float32)
         self.theta = np.zeros((actions, self.rep.features()), dtype=np.float32)
 
-    def policy(self, x: np.ndarray):
-        l = compute_logits(self.theta, x)
+    def policy(self, obs: np.ndarray):
+        l = compute_logits(self.theta, obs)
         return softmax(l, self.tau)
 
     def update(self, x, a, xp, r, gamma):

--- a/src/algorithms/tc/TCAgent.py
+++ b/src/algorithms/tc/TCAgent.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from abc import abstractmethod
 from typing import Any, Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 from PyExpUtils.utils.random import sample
 from ReplayTables.interface import Timestep
 from ReplayTables.ingress.LagBuffer import LagBuffer
@@ -60,38 +60,38 @@ class TCAgent(BaseAgent):
     # ----------------------
     # -- RLGlue interface --
     # ----------------------
-    def start(self, s: np.ndarray):
+    def start(self, obs: np.ndarray):
         self.lag.flush()
 
-        x = self.get_rep(s)
-        pi = self.policy(x)
+        x_encoded = self.get_rep(obs)
+        pi = self.policy(x_encoded)
         a = sample(pi, rng=self.rng)
         self.lag.add(Timestep(
-            x=x,
+            x=x_encoded,
             a=a,
             r=None,
             gamma=0,
             terminal=False,
         ))
-        return a, self.get_info()
+        return a
 
-    def step(self, r: float, sp: np.ndarray | None, extra: Dict[str, Any]):
+    def step(self, reward: float, obs: np.ndarray | None, extra: Dict[str, Any]):
         a = -1
 
         # sample next action
-        xp = None
-        if sp is not None:
-            xp = self.get_rep(sp)
-            pi = self.policy(xp)
+        xp_encoded = None
+        if obs is not None:
+            xp_encoded = self.get_rep(obs)
+            pi = self.policy(xp_encoded)
             a = sample(pi, rng=self.rng)
 
         # see if the problem specified a discount term
         gamma = extra.get('gamma', 1.0)
 
         interaction = Timestep(
-            x=xp,
+            x=xp_encoded,
             a=a,
-            r=r,
+            r=reward,
             gamma=self.gamma * gamma,
             terminal=False,
         )
@@ -105,13 +105,13 @@ class TCAgent(BaseAgent):
                 gamma=exp.gamma,
             )
 
-        return a, self.get_info()
+        return a
 
-    def end(self, r: float, extra: Dict[str, Any]):
+    def end(self, reward: float, extra: Dict[str, Any]):
         interaction = Timestep(
             x=None,
             a=-1,
-            r=r,
+            r=reward,
             gamma=0,
             terminal=True,
         )

--- a/src/algorithms/tc/tc_replay/ESARSA.py
+++ b/src/algorithms/tc/tc_replay/ESARSA.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numba import njit
 from typing import Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from algorithms.tc.tc_replay.TCAgentReplay import TCAgentReplay
 from utils.checkpoint import checkpointable

--- a/src/algorithms/tc/tc_replay/QL.py
+++ b/src/algorithms/tc/tc_replay/QL.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numba import njit
 from typing import Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from algorithms.tc.tc_replay.TCAgentReplay import TCAgentReplay
 from utils.checkpoint import checkpointable

--- a/src/algorithms/tc/tc_replay/TCAgentReplay.py
+++ b/src/algorithms/tc/tc_replay/TCAgentReplay.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from abc import abstractmethod
 from typing import Any, Dict, Tuple
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 from PyExpUtils.utils.random import sample
 from ReplayTables.interface import Timestep
 from ReplayTables.registry import build_buffer

--- a/src/environments/CliffWalking.py
+++ b/src/environments/CliffWalking.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import gymnasium
 from gymnasium.spaces import Box
-from RlGlue.environment import BaseEnvironment
+from rlglue.environment import BaseEnvironment
 import numpy as np
 
 class CliffWalking(BaseEnvironment):
@@ -12,10 +12,14 @@ class CliffWalking(BaseEnvironment):
         s, info = self.env.reset()
         return self.one_hot_state(s)
 
-    def step(self, a):
-        sp, r, t, _, info = self.env.step(a)
+    def step(self, action):
+        sp, r, terminated_gym, truncated_gym, info = self.env.step(action) # gymnasium returns terminated and truncated
+        
+        # If the underlying gym env only returned a single 'done' flag (as 't' in the old code):
+        # terminated = t
+        # truncated = False
 
-        return (r, self.one_hot_state(sp), t, {})
+        return self.one_hot_state(sp), float(r), terminated_gym, truncated_gym, {}
     
     def one_hot_state(self, state):
         one_hot = np.zeros(self.env.observation_space.n, dtype=np.float64)

--- a/src/environments/Gridworld/Gridworld.py
+++ b/src/environments/Gridworld/Gridworld.py
@@ -1,5 +1,5 @@
 import gymnasium
-from RlGlue.environment import BaseEnvironment
+from rlglue.environment import BaseEnvironment
 import numpy as np
 
 class Gridworld(BaseEnvironment):
@@ -10,10 +10,18 @@ class Gridworld(BaseEnvironment):
         s, info = self.env.reset()
         return self.one_hot_state(s)
 
-    def step(self, a):
-        sp, r, t, _, info = self.env.step(a)
+    def step(self, action):
+        sp, r, terminated, truncated_gym, info = self.env.step(action) # gymnasium returns terminated and truncated
+        # Assuming truncated_gym is the truncated flag. If not, and only a single 'done' is available,
+        # then terminated = t, truncated = False.
+        # If the underlying env (gymnasium) gives both, we use them.
+        
+        # If the gym env only returns a single done flag (often called `t` or `terminated`):
+        # sp, r, t, info = self.env.step(action) # if it were a 4-tuple return
+        # terminated = t
+        # truncated = False
 
-        return (r, self.one_hot_state(sp), t, {})
+        return self.one_hot_state(sp), float(r), terminated, truncated_gym, {}
     
     def one_hot_state(self, state):
         one_hot = np.zeros(self.env.observation_space.n, dtype=np.float64)

--- a/src/environments/Gym.py
+++ b/src/environments/Gym.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import gymnasium
 from gymnasium.spaces import Box
-from RlGlue.environment import BaseEnvironment
+from rlglue.environment import BaseEnvironment
 import numpy as np
 
 class Gym(BaseEnvironment):
@@ -16,7 +16,7 @@ class Gym(BaseEnvironment):
         s, info = self.env.reset(seed=self.seed)
         return np.asarray(s, dtype=np.float64).reshape(-1,), info
 
-    def step(self, a):
-        sp, r, t, _, info = self.env.step(a)
+    def step(self, action):
+        sp, r, terminated, truncated, info = self.env.step(action)
 
-        return (r, np.asarray(sp, dtype=np.float64).reshape(-1,), t, {})
+        return (np.asarray(sp, dtype=np.float64).reshape(-1,), float(r), terminated, truncated, info)

--- a/src/environments/PlantGrowthChamber/MockPlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/MockPlantGrowthChamber.py
@@ -82,10 +82,10 @@ class MockPlantGrowthChamber(PlantGrowthChamber):
             super().get_plant_stats()
 
     async def step(self, action: np.ndarray):
-        reward, observation, terminal, info = await super().step(action)
+        observation, reward, terminated, truncated, info = await super().step(action)
         if self.simulate and action == 0:
-            reward -= 0.5 * abs(reward)
-        return reward, observation, terminal, info
+            reward -= 0.5 * abs(reward) # type: ignore
+        return observation, reward, terminated, truncated, info
 
     async def put_action(self, action: int):
         self.last_action = action

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -8,7 +8,7 @@ import numpy as np
 from PIL import Image
 
 from environments.PlantGrowthChamber.utils import get_session
-from utils.RlGlue.environment import BaseAsyncEnvironment
+from rlglue.environment import BaseAsyncEnvironment
 from utils.metrics import UnbiasedExponentialMovingAverage as UEMA
 from .cv import process_image
 from .zones import get_zone
@@ -163,8 +163,9 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         self.reward = self.reward_function()
         logger.info(f"Step {self.n_step} completed. Reward: {self.reward}, Terminal: {terminal}")
         self.n_step += 1
+        truncated = False # Typically, if an env has a terminal flag, truncated is False unless a time limit is also hit.
 
-        return self.reward, observation, terminal, self.get_info()
+        return observation, float(self.reward), terminal, truncated, self.get_info()
 
     def is_night(self):
         local_time = self.get_local_time()

--- a/src/environments/PlantSimulator.py
+++ b/src/environments/PlantSimulator.py
@@ -2,7 +2,7 @@ import os
 from math import sin, cos, pi
 import numpy as np
 import pandas as pd
-from RlGlue.environment import BaseEnvironment
+from rlglue.environment import BaseEnvironment
 from utils.functions import PiecewiseLinear
 from utils.metrics import UnbiasedExponentialMovingAverage as uema
 from utils.metrics import iqm
@@ -95,11 +95,10 @@ class PlantSimulator(BaseEnvironment):
         self.current_state = self.get_observation()
 
         self.reward = self.reward_function()
+        terminated = self.num_steps == self.terminal_step
+        truncated = False
 
-        if self.num_steps == self.terminal_step:
-            return self.reward, self.current_state, True, self.get_info()
-        else:
-            return self.reward, self.current_state, False, self.get_info()
+        return self.current_state, float(self.reward), terminated, truncated, self.get_info()
 
     def overnight_trace(self):
         last_night_obs = self.observed_areas[-1]

--- a/src/problems/BaseProblem.py
+++ b/src/problems/BaseProblem.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 from RlGlue.environment import BaseEnvironment
 
 from experiment.ExperimentModel import ExperimentModel

--- a/src/problems/CVPlantGrowthChamber.py
+++ b/src/problems/CVPlantGrowthChamber.py
@@ -1,4 +1,4 @@
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from environments.PlantGrowthChamber.CVPlantGrowthChamber import CVPlantGrowthChamber as Env
 from experiment.ExperimentModel import ExperimentModel

--- a/src/problems/CVPlantGrowthChamberIntensity.py
+++ b/src/problems/CVPlantGrowthChamberIntensity.py
@@ -1,4 +1,4 @@
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from environments.PlantGrowthChamber.CVPlantGrowthChamberIntensity import CVPlantGrowthChamberIntensity as Env
 from experiment.ExperimentModel import ExperimentModel

--- a/src/problems/MockCVPlantGrowthChamberDiscrete.py
+++ b/src/problems/MockCVPlantGrowthChamberDiscrete.py
@@ -1,4 +1,4 @@
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from environments.PlantGrowthChamber.MockCVPlantGrowthChamberDiscrete import (
     MockCVPlantGrowthChamberDiscrete as Env,

--- a/src/problems/MockPlantGrowthChamber.py
+++ b/src/problems/MockPlantGrowthChamber.py
@@ -1,4 +1,4 @@
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from environments.PlantGrowthChamber.MockPlantGrowthChamber import MockPlantGrowthChamber as Env
 from experiment.ExperimentModel import ExperimentModel

--- a/src/problems/MockTemporalPlantGrowthChamber.py
+++ b/src/problems/MockTemporalPlantGrowthChamber.py
@@ -1,4 +1,4 @@
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from environments.PlantGrowthChamber.MockTemporalPlantGrowthChamber import (
     MockTemporalPlantGrowthChamber as Env,

--- a/src/problems/MockTemporalPlantGrowthChamberDiscrete.py
+++ b/src/problems/MockTemporalPlantGrowthChamberDiscrete.py
@@ -1,4 +1,4 @@
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from environments.PlantGrowthChamber.MockTemporalPlantGrowthChamberDiscrete import (
     MockTemporalPlantGrowthChamberDiscrete as Env,

--- a/src/problems/PlantGrowthChamberBinary.py
+++ b/src/problems/PlantGrowthChamberBinary.py
@@ -1,4 +1,4 @@
-from PyExpUtils.collection.Collector import Collector
+from ml_instrumentation.Collector import Collector
 
 from environments.PlantGrowthChamber.PlantGrowthChamberIntensity import (
     PlantGrowthChamberIntensity as Env,

--- a/src/problems/registry.py
+++ b/src/problems/registry.py
@@ -1,6 +1,7 @@
 from importlib import import_module
+from problems.BaseProblem import BaseProblem
 
-def getProblem(name):
+def getProblem(name: str) -> type[BaseProblem]:
     
     mod = import_module(f'problems.{name}')
 

--- a/src/utils/results.py
+++ b/src/utils/results.py
@@ -1,0 +1,118 @@
+from collections.abc import Callable, Iterable, Sequence
+import importlib
+from pathlib import Path
+from PyExpUtils.models.ExperimentDescription import ExperimentDescription, loadExperiment
+from PyExpUtils.results.tools import getHeader, getParamsAsDict
+from PyExpUtils.results.indices import listIndices
+from ml_instrumentation.reader import load_all_results, get_run_ids
+
+import polars as pl
+
+class Result[Exp: ExperimentDescription]:
+    def __init__(self, exp_path: str | Path, exp: Exp, metrics: Sequence[str] | None = None):
+        self.exp_path = str(exp_path)
+        self.exp = exp
+        self.metrics = metrics
+
+    def load(self):
+        db_path = self.exp.buildSaveContext(0).resolve('results.db')
+
+        if not Path(db_path).exists():
+            return None
+
+        dfs: list[pl.DataFrame] = []
+        for param_id in range(self.exp.numPermutations()):
+            params = getParamsAsDict(self.exp, param_id)
+            run_ids = get_run_ids(db_path, params)
+
+            df = load_all_results(db_path, self.metrics, run_ids)
+            dfs.append(df)
+
+        return pl.concat(dfs)
+
+    @property
+    def filename(self):
+        return self.exp_path.split('/')[-1].removesuffix('.json')
+
+
+class ResultCollection[Exp: ExperimentDescription]:
+    def __init__(self, path: str | Path | None = None, metrics: Sequence[str] | None = None, Model: type[Exp] = ExperimentDescription):
+        self.metrics = metrics
+        self.Model = Model
+
+        if path is None:
+            main_file = importlib.import_module('__main__').__file__
+            assert main_file is not None
+            path = Path(main_file).parent
+
+        self.path = Path(path)
+
+        project = Path.cwd()
+        paths = self.path.glob('**/*.json')
+        paths = map(lambda p: p.relative_to(project), paths)
+        paths = map(str, paths)
+        self.paths = list(paths)
+
+
+    def _result(self, path: str):
+        exp = loadExperiment(path, self.Model)
+        return Result[Exp](path, exp, self.metrics)
+
+
+    def get_hyperparameter_columns(self):
+        hypers = set[str]()
+
+        for path in self.paths:
+            exp = loadExperiment(path, self.Model)
+            hypers |= set(getHeader(exp))
+
+        return sorted(hypers)
+
+
+    def groupby_directory(self, level: int):
+        uniques = set(
+            p.split('/')[level] for p in self.paths
+        )
+
+        for group in uniques:
+            group_paths = [p for p in self.paths if p.split('/')[level] == group]
+            results = map(self._result, group_paths)
+            yield group, list(results)
+
+
+    def __iter__(self):
+        return map(self._result, self.paths)
+
+
+def detect_missing_indices(exp: ExperimentDescription, runs: int, base: str = './'):
+    context = exp.buildSaveContext(0, base=base)
+    header = getHeader(exp)
+    path = context.resolve('results.db')
+
+    if not context.exists('results.db'):
+        yield from listIndices(exp, runs)
+        return
+
+    n_params = exp.numPermutations()
+    for param_id in range(n_params):
+        run_ids = set(get_run_ids(path, getParamsAsDict(exp, param_id, header=header)))
+
+        for seed in range(runs):
+            run_id = seed * n_params + param_id
+            if run_id not in run_ids:
+                yield run_id
+
+
+def gather_missing_indices(experiment_paths: Iterable[str], runs: int, loader: Callable[[str], ExperimentDescription] = loadExperiment, base: str = './'):
+    path_to_indices: dict[str, list[int]] = {}
+
+    for path in experiment_paths:
+        exp = loader(path)
+        indices = detect_missing_indices(exp, runs, base=base)
+        indices = sorted(indices)
+        path_to_indices[path] = indices
+
+        size = exp.numPermutations() * runs
+        print(path, f'{len(indices)} / {size}')
+
+    return path_to_indices


### PR DESCRIPTION
This continues the process of updating your repository based on new dependencies and a provided set of changes, focusing on the `src/` and `scripts/` directories after clarifying the scope for example files.

Here's what I did:
- In `scripts/local.py`:
  - I updated the import for `gather_missing_indices` to `utils.results`.
  - I removed the `--cpus` argparse argument and updated `Pool` usage.
  - I added `pool.close()`.
- In `src/main.py`:
  - I removed the `Box2D` import.
  - I updated imports for `ml_instrumentation` and `rlglue`.
  - I changed `collector.setIdx` to `collector.set_experiment_id`.
  - I changed `interaction.t` to `interaction.term`.
  - I updated the result saving logic.
- In `src/algorithms/BaseAgent.py`:
  - I changed the base class to `rlglue.agent.BaseAgent`.
  - I updated the `Collector` import to `ml_instrumentation.Collector`.

I've also verified that earlier changes to `pyproject.toml`, `.gitignore`, `LICENSE`, and `clusters/home.json` are still correct from previous work.

The file `src/continuing_main.py` was not found, so I couldn't apply the related changes from the provided information.

Work is ongoing. Next, I'll be looking at files in `src/algorithms/nn/`, `src/algorithms/tc/`, `src/environments/`, `src/problems/`, and adding `src/utils/results.py`.

Just to confirm, the prerequisites for this work are:
- Python 3.11+
- Rust
- SWIG