### PR TITLE
Update Overnight Transition

### DIFF
--- a/src/environments/PlantGrowthChamber/MockPlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/MockPlantGrowthChamber.py
@@ -88,6 +88,7 @@ class MockPlantGrowthChamber(PlantGrowthChamber):
         return reward, observation, terminal, info
 
     async def put_action(self, action: int):
+        logger.debug(f"action: {action}")
         self.last_action = action
 
     async def sleep_until(self, wake_time: datetime):

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -152,7 +152,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         return observation, self.get_info()
 
     async def step(self, action: np.ndarray):
-        logger.info(f"Step {self.n_step} with action {action}")
+        logger.info(f"Local time: {self.get_local_time()}. Step {self.n_step} with action {action}")
         await self.put_action(action)
 
         terminal = self.get_terminal()
@@ -162,7 +162,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             await self.sleep_until_next_step(self.duration)
             await self.lights_off_and_sleep_until_morning()
             action = self.dim_action
-            logger.info("Nighttime ended. Reference spectrum applied.")
+            logger.info(f"Local time: {self.get_local_time()}. Nighttime ended. Reference spectrum applied.")
             woke = True
 
         # calculate the time left until the next step
@@ -172,7 +172,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             reward = self.reward_function()
         else:
             reward = 0
-        logger.info(f"Step {self.n_step} completed. Reward: {reward}, Terminal: {terminal}")
+        logger.info(f"Local time: {self.get_local_time()}. Step {self.n_step} completed. Reward: {reward}, Terminal: {terminal}")
         self.n_step += 1
 
         return reward, observation, terminal, self.get_info()
@@ -181,7 +181,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         if local_time is None:
             local_time = self.get_local_time()
         is_night = local_time.hour >= 21 or local_time.hour < 9
-        logger.info(f"Local time: {local_time}, is_night: {is_night}")
+        logger.info(f"Time: {local_time}, is_night: {is_night}")
         return is_night
 
     def get_next_step_time(self, duration: timedelta):

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -178,6 +178,16 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         return reward, observation, terminal, self.get_info()
 
     def is_night(self, local_time: datetime | None = None) -> bool:
+        """
+        Determine whether the given time falls within nighttime hours.
+        
+        Args:
+            local_time (datetime | None): The local time to check. If None, the current local time
+                is retrieved using self.get_local_time().
+        
+        Returns:
+            bool: True if the time is between 9 PM and 9 AM, False otherwise.
+        """
         if local_time is None:
             local_time = self.get_local_time()
         is_night = local_time.hour >= 21 or local_time.hour < 9

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -161,7 +161,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         if self.enforce_night and self.is_night(self.get_local_time() + self.duration):
             await self.sleep_until_next_step(self.duration)
             await self.lights_off_and_sleep_until_morning()
-            action = self.dim_action
+            await self.put_action(self.dim_action)
             logger.info(f"Local time: {self.get_local_time()}. Nighttime ended. Reference spectrum applied.")
             woke = True
 

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -181,7 +181,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         if local_time is None:
             local_time = self.get_local_time()
         is_night = local_time.hour >= 21 or local_time.hour < 9
-        logger.info(f"Time: {local_time}, is_night: {is_night}")
+        logger.info(f"{local_time} is_night: {is_night}")
         return is_night
 
     def get_next_step_time(self, duration: timedelta):


### PR DESCRIPTION
Tested with MockPlantGrowthChamber.

Step count is off by one because for some reason /data/nazmus_exp/z11c1 data started at 9:20 instead of 9:10

```py
[2025-05-29 03:34:29] DEBUG:MockPlantGrowthChamber action: [0.26865 0.51435 0.2187  0.      0.2241  0.40905]
[2025-05-29 03:34:29] INFO:PlantGrowthChamber 2022-07-22 20:50:02-06:00 is_night: False
[2025-05-29 03:34:30] INFO:PlantGrowthChamber Local time: 2022-07-22 20:50:02-06:00. Step 70 completed. Reward: 0, Terminal: False
[2025-05-29 03:34:31] INFO:PlantGrowthChamber Local time: 2022-07-22 20:50:02-06:00. Step 71 with action [0.398 0.762 0.324 0.    0.332 0.606]
[2025-05-29 03:34:31] DEBUG:MockPlantGrowthChamber action: [0.398 0.762 0.324 0.    0.332 0.606]
[2025-05-29 03:34:31] INFO:PlantGrowthChamber 2022-07-22 21:00:02-06:00 is_night: True
[2025-05-29 03:34:31] DEBUG:MockPlantGrowthChamber action: [0. 0. 0. 0. 0. 0.]
[2025-05-29 03:34:31] INFO:PlantGrowthChamber Nighttime enforced!
[2025-05-29 03:34:31] DEBUG:MockPlantGrowthChamber action: [0.26865 0.51435 0.2187  0.      0.2241  0.40905]
[2025-05-29 03:34:31] INFO:PlantGrowthChamber Local time: 2022-07-23 09:00:01-06:00. Nighttime ended. Reference spectrum applied.
[2025-05-29 03:34:31] INFO:PlantGrowthChamber Local time: 2022-07-23 09:10:01-06:00. Step 71 completed. Reward: -0.03668402777777786, Terminal: False
[2025-05-29 03:34:31] INFO:PlantGrowthChamber Local time: 2022-07-23 09:10:01-06:00. Step 72 with action [0.398 0.762 0.324 0.    0.332 0.606]
[2025-05-29 03:34:31] DEBUG:MockPlantGrowthChamber action: [0.398 0.762 0.324 0.    0.332 0.606]
[2025-05-29 03:34:31] INFO:PlantGrowthChamber 2022-07-23 09:20:01-06:00 is_night: False
[2025-05-29 03:34:31] INFO:PlantGrowthChamber Local time: 2022-07-23 09:20:01-06:00. Step 72 completed. Reward: 0, Terminal: False
```