### PR TITLE
fix: address copilot review on smart-plug integration

### DIFF
--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -53,6 +53,8 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         )
         self.power = dict.fromkeys(POWER_KEYS, 0.0)
         self.power_record: dict = {}
+        self.last_smart_plug_time = None
+        self.smart_plug_interval = timedelta(minutes=5)
 
         # Cleaning state
         self.cv_state = None
@@ -200,10 +202,18 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
     async def get_power(self):
         if self.smart_plug_client is None or self.zone.smart_plug_host is None:
             return
-        if self.get_time().minute % 5 != 0:
+
+        now = self.get_time()
+        on_boundary = now.minute % 5 == 0
+        overdue = (
+            self.last_smart_plug_time is None
+            or (now - self.last_smart_plug_time) > self.smart_plug_interval
+        )
+        if not (on_boundary or overdue):
             return
 
         reading = await self.smart_plug_client.read(self.zone.smart_plug_host)
+        self.last_smart_plug_time = now
         if reading is not None:
             self.power = reading
             self.power_record = reading

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -47,14 +47,12 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
 
         # Smart plug
         # self.power: agent-facing carry-over of last successful reading
-        # self.power_record: per-step audit value sent to CSV/WandB; sticky between fetches (matches get_plant_stats), None on failure
+        # self.power_record: per-step audit value sent to CSV/WandB; sticky between fetches, None on failure
         self.smart_plug_client = (
             SmartPlugClient() if self.zone.smart_plug_host is not None else None
         )
         self.power = dict.fromkeys(POWER_KEYS, 0.0)
         self.power_record: dict = {}
-        self.last_smart_plug_time = None
-        self.smart_plug_interval = timedelta(minutes=5)
 
         # Cleaning state
         self.cv_state = None
@@ -202,16 +200,10 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
     async def get_power(self):
         if self.smart_plug_client is None or self.zone.smart_plug_host is None:
             return
-
-        now = self.get_time()
-        if (
-            self.last_smart_plug_time is not None
-            and (now - self.last_smart_plug_time) < self.smart_plug_interval
-        ):
+        if self.get_time().minute % 5 != 0:
             return
 
         reading = await self.smart_plug_client.read(self.zone.smart_plug_host)
-        self.last_smart_plug_time = now
         if reading is not None:
             self.power = reading
             self.power_record = reading

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -48,7 +48,9 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         # Smart plug
         # self.power: agent-facing carry-over of last successful reading
         # self.power_record: per-step audit value sent to CSV/WandB; None on failure, empty when no read attempted
-        self.smart_plug_client = SmartPlugClient()
+        self.smart_plug_client = (
+            SmartPlugClient() if self.zone.smart_plug_host is not None else None
+        )
         self.power = dict.fromkeys(POWER_KEYS, 0.0)
         self.power_record: dict = {}
         self.last_smart_plug_time = None
@@ -198,7 +200,8 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             self.df = pd.DataFrame()
 
     async def get_power(self):
-        if self.zone.smart_plug_host is None:
+        self.power_record = {}
+        if self.smart_plug_client is None or self.zone.smart_plug_host is None:
             return
 
         now = self.get_time()

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -47,7 +47,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
 
         # Smart plug
         # self.power: agent-facing carry-over of last successful reading
-        # self.power_record: per-step audit value sent to CSV/WandB; None on failure, empty when no read attempted
+        # self.power_record: per-step audit value sent to CSV/WandB; sticky between fetches (matches get_plant_stats), None on failure
         self.smart_plug_client = (
             SmartPlugClient() if self.zone.smart_plug_host is not None else None
         )
@@ -200,7 +200,6 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             self.df = pd.DataFrame()
 
     async def get_power(self):
-        self.power_record = {}
         if self.smart_plug_client is None or self.zone.smart_plug_host is None:
             return
 

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -49,7 +49,9 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         # self.power: agent-facing carry-over of last successful reading
         # self.power_record: per-step audit value sent to CSV/WandB; sticky between fetches, None on failure
         self.smart_plug_client = (
-            SmartPlugClient() if self.zone.smart_plug_host is not None else None
+            SmartPlugClient()
+            if zone is not None and self.zone.smart_plug_host is not None
+            else None
         )
         self.power = dict.fromkeys(POWER_KEYS, 0.0)
         self.power_record: dict = {}

--- a/src/environments/PlantGrowthChamber/SmartPlugClient.py
+++ b/src/environments/PlantGrowthChamber/SmartPlugClient.py
@@ -54,6 +54,4 @@ class SmartPlugClient:
                 try:
                     await dev.disconnect()
                 except Exception:
-                    logger.warning(
-                        "kasa disconnect error for %s", host, exc_info=True
-                    )
+                    logger.warning("kasa disconnect error for %s", host, exc_info=True)

--- a/src/environments/PlantGrowthChamber/SmartPlugClient.py
+++ b/src/environments/PlantGrowthChamber/SmartPlugClient.py
@@ -51,4 +51,9 @@ class SmartPlugClient:
             return None
         finally:
             if dev is not None:
-                await dev.disconnect()
+                try:
+                    await dev.disconnect()
+                except Exception:
+                    logger.warning(
+                        "kasa disconnect error for %s", host, exc_info=True
+                    )

--- a/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
+++ b/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
@@ -42,10 +42,8 @@ async def test_get_power_carryover_records_null_on_failure(kasa_creds):
 async def test_get_power_is_noop_when_zone_has_no_plug(kasa_creds):
     chamber = PlantGrowthChamber(zone="alliance-zone03", timezone="Etc/UTC")
     assert chamber.zone.smart_plug_host is None
+    assert chamber.smart_plug_client is None
 
-    chamber.smart_plug_client.read = AsyncMock(
-        side_effect=AssertionError("should not be called when smart_plug_host is None")
-    )
     await chamber.get_power()
 
     assert chamber.power_record == {}
@@ -62,6 +60,9 @@ async def test_get_power_respects_5_minute_gate(kasa_creds):
     chamber.smart_plug_client.read = AsyncMock(return_value=successful)
 
     await chamber.get_power()
-    await chamber.get_power()
+    assert chamber.power_record == successful
 
+    await chamber.get_power()
     assert chamber.smart_plug_client.read.await_count == 1
+    assert chamber.power_record == {}
+    assert chamber.power == successful

--- a/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
+++ b/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
@@ -64,5 +64,5 @@ async def test_get_power_respects_5_minute_gate(kasa_creds):
 
     await chamber.get_power()
     assert chamber.smart_plug_client.read.await_count == 1
-    assert chamber.power_record == {}
+    assert chamber.power_record == successful
     assert chamber.power == successful

--- a/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
+++ b/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
@@ -63,7 +63,7 @@ async def test_get_power_is_noop_when_zone_has_no_plug(kasa_creds):
 
 
 @pytest.mark.asyncio
-async def test_get_power_only_fetches_on_five_minute_boundary(kasa_creds, monkeypatch):
+async def test_get_power_fetches_on_five_minute_boundary(kasa_creds, monkeypatch):
     chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
     successful = {"power": 5.0, "voltage": 120.0, "current": 0.04}
     chamber.smart_plug_client.read = AsyncMock(return_value=successful)
@@ -79,5 +79,23 @@ async def test_get_power_only_fetches_on_five_minute_boundary(kasa_creds, monkey
     assert chamber.power == successful
 
     _pin_time(chamber, monkeypatch, minute=10)
+    await chamber.get_power()
+    assert chamber.smart_plug_client.read.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_power_recovers_when_boundary_is_missed(kasa_creds, monkeypatch):
+    """If the step loop drifts past a 5-min boundary, the next call still fetches."""
+    chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
+    successful = {"power": 5.0, "voltage": 120.0, "current": 0.04}
+    chamber.smart_plug_client.read = AsyncMock(return_value=successful)
+
+    _pin_time(chamber, monkeypatch, minute=5)
+    await chamber.get_power()
+    assert chamber.smart_plug_client.read.await_count == 1
+
+    # Step loop missed minute=10 entirely, lands at :11. Not on boundary,
+    # but elapsed is 6 min > 5 min interval → fetch via the overdue fallback.
+    _pin_time(chamber, monkeypatch, minute=11)
     await chamber.get_power()
     assert chamber.smart_plug_client.read.await_count == 2

--- a/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
+++ b/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
@@ -1,8 +1,12 @@
+from datetime import datetime
 from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from environments.PlantGrowthChamber.PlantGrowthChamber import PlantGrowthChamber
+
+UTC = ZoneInfo("Etc/UTC")
 
 
 @pytest.fixture
@@ -11,10 +15,17 @@ def kasa_creds(monkeypatch):
     monkeypatch.setenv("KASA_PASSWORD", "p")
 
 
+def _pin_time(chamber, monkeypatch, minute: int):
+    monkeypatch.setattr(
+        chamber, "get_time", lambda: datetime(2026, 5, 6, 12, minute, tzinfo=UTC)
+    )
+
+
 @pytest.mark.asyncio
-async def test_get_power_carryover_records_null_on_failure(kasa_creds):
+async def test_get_power_carryover_records_null_on_failure(kasa_creds, monkeypatch):
     chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
     assert chamber.zone.smart_plug_host == "142.244.4.73"
+    _pin_time(chamber, monkeypatch, minute=5)
 
     successful = {"power": 5.0, "voltage": 120.0, "current": 0.04}
     chamber.smart_plug_client.read = AsyncMock(side_effect=[successful, None])
@@ -26,8 +37,6 @@ async def test_get_power_carryover_records_null_on_failure(kasa_creds):
     assert info["power"] == 5.0
     assert info["voltage"] == 120.0
     assert info["current"] == 0.04
-
-    chamber.last_smart_plug_time = None
 
     await chamber.get_power()
     assert chamber.power == successful
@@ -54,15 +63,21 @@ async def test_get_power_is_noop_when_zone_has_no_plug(kasa_creds):
 
 
 @pytest.mark.asyncio
-async def test_get_power_respects_5_minute_gate(kasa_creds):
+async def test_get_power_only_fetches_on_five_minute_boundary(kasa_creds, monkeypatch):
     chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
     successful = {"power": 5.0, "voltage": 120.0, "current": 0.04}
     chamber.smart_plug_client.read = AsyncMock(return_value=successful)
 
+    _pin_time(chamber, monkeypatch, minute=5)
     await chamber.get_power()
     assert chamber.power_record == successful
 
+    _pin_time(chamber, monkeypatch, minute=6)
     await chamber.get_power()
     assert chamber.smart_plug_client.read.await_count == 1
     assert chamber.power_record == successful
     assert chamber.power == successful
+
+    _pin_time(chamber, monkeypatch, minute=10)
+    await chamber.get_power()
+    assert chamber.smart_plug_client.read.await_count == 2


### PR DESCRIPTION
Follow-up to #319 addressing the Copilot review plus a cadence mismatch I caught while iterating.

## Summary
- **Skip `SmartPlugClient` construction on non-plug zones.** Avoids a spurious "missing creds" warning whenever a zone without a smart plug is run.
- **Guard `dev.disconnect()` in the `finally` block.** A cleanup failure no longer overrides `read()`'s "return None on any failure" contract.
- **Align the smart-plug fetch with the CSV writer's 5-minute clock.** The original `now - last_fetch >= 5min` gate drifted out of phase with the CSV's `env.time.minute % 5 == 0` writer — every CSV row picked up an up-to-5-min stale reading. New gate is `(minute % 5 == 0) OR overdue` so fetches land on CSV-write boundaries, with the elapsed-time fallback recovering if the step loop drifts past one.
- **Short-circuit on `zone is not None` before dereferencing `self.zone.smart_plug_host`.** Keeps `PlantGrowthChamber(zone=None)` from crashing during construction (per Copilot review on this PR).

## Test plan
- [x] `pytest tests/environments/PlantGrowthChamber/test_SmartPlugClient.py tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py` — 8/8 pass
- [x] Boundary fetch + drift-recovery covered by `test_get_power_fetches_on_five_minute_boundary` and `test_get_power_recovers_when_boundary_is_missed`
- [ ] Live test on Z1 alongside the rest of the smart-plug work (chambers blocked by current flowering-time experiment)

## Follow-up
Separate PR will:
- Drop the kasa cadence gate entirely so the plug is read every minute (matches `get_image`'s cadence — a 5-min throttle is artificial when we already pay per-minute network latency for images, and the CSV writer just picks up the most recent reading).
- Apply the same `(minute % 5 == 0) OR overdue` pattern to `get_plant_stats`, which currently has the same relative-cadence-vs-wall-clock-CSV mismatch the kasa fix addresses here.
