### PR TITLE
fix: align telemetry cadences with the CSV 5-min clock

### DIFF
--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -146,7 +146,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         now = self.get_time()
         on_boundary = now.minute % 5 == 0
         overdue = (
-            self.last_cv_time is None or (now - self.last_cv_time) > self.cv_interval
+            self.last_cv_time is None or (now - self.last_cv_time) >= self.cv_interval
         )
         if not (on_boundary or overdue):
             return

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -55,8 +55,6 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         )
         self.power = dict.fromkeys(POWER_KEYS, 0.0)
         self.power_record: dict = {}
-        self.last_smart_plug_time = None
-        self.smart_plug_interval = timedelta(minutes=5)
 
         # Cleaning state
         self.cv_state = None
@@ -143,13 +141,14 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             self.df = pd.DataFrame()
             return
 
-        # Check update frequency (every 5 minutes or if never run)
+        # 5-minute cadence aligned with the CSV writer (env.time.minute % 5 == 0),
+        # with an elapsed-time fallback so a missed boundary still triggers a fetch.
         now = self.get_time()
-        if (
-            self.last_cv_time is not None
-            and (now - self.last_cv_time) < self.cv_interval
-        ):
-            # Not time to update yet, keep existing df/image or use empty if none
+        on_boundary = now.minute % 5 == 0
+        overdue = (
+            self.last_cv_time is None or (now - self.last_cv_time) > self.cv_interval
+        )
+        if not (on_boundary or overdue):
             return
 
         session = await self._ensure_session()
@@ -205,17 +204,7 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
         if self.smart_plug_client is None or self.zone.smart_plug_host is None:
             return
 
-        now = self.get_time()
-        on_boundary = now.minute % 5 == 0
-        overdue = (
-            self.last_smart_plug_time is None
-            or (now - self.last_smart_plug_time) > self.smart_plug_interval
-        )
-        if not (on_boundary or overdue):
-            return
-
         reading = await self.smart_plug_client.read(self.zone.smart_plug_host)
-        self.last_smart_plug_time = now
         if reading is not None:
             self.power = reading
             self.power_record = reading

--- a/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
+++ b/tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py
@@ -1,12 +1,8 @@
-from datetime import datetime
 from unittest.mock import AsyncMock
-from zoneinfo import ZoneInfo
 
 import pytest
 
 from environments.PlantGrowthChamber.PlantGrowthChamber import PlantGrowthChamber
-
-UTC = ZoneInfo("Etc/UTC")
 
 
 @pytest.fixture
@@ -15,17 +11,10 @@ def kasa_creds(monkeypatch):
     monkeypatch.setenv("KASA_PASSWORD", "p")
 
 
-def _pin_time(chamber, monkeypatch, minute: int):
-    monkeypatch.setattr(
-        chamber, "get_time", lambda: datetime(2026, 5, 6, 12, minute, tzinfo=UTC)
-    )
-
-
 @pytest.mark.asyncio
-async def test_get_power_carryover_records_null_on_failure(kasa_creds, monkeypatch):
+async def test_get_power_carryover_records_null_on_failure(kasa_creds):
     chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
     assert chamber.zone.smart_plug_host == "142.244.4.73"
-    _pin_time(chamber, monkeypatch, minute=5)
 
     successful = {"power": 5.0, "voltage": 120.0, "current": 0.04}
     chamber.smart_plug_client.read = AsyncMock(side_effect=[successful, None])
@@ -63,39 +52,12 @@ async def test_get_power_is_noop_when_zone_has_no_plug(kasa_creds):
 
 
 @pytest.mark.asyncio
-async def test_get_power_fetches_on_five_minute_boundary(kasa_creds, monkeypatch):
+async def test_get_power_fetches_every_call(kasa_creds):
     chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
     successful = {"power": 5.0, "voltage": 120.0, "current": 0.04}
     chamber.smart_plug_client.read = AsyncMock(return_value=successful)
 
-    _pin_time(chamber, monkeypatch, minute=5)
-    await chamber.get_power()
-    assert chamber.power_record == successful
+    for _ in range(3):
+        await chamber.get_power()
 
-    _pin_time(chamber, monkeypatch, minute=6)
-    await chamber.get_power()
-    assert chamber.smart_plug_client.read.await_count == 1
-    assert chamber.power_record == successful
-    assert chamber.power == successful
-
-    _pin_time(chamber, monkeypatch, minute=10)
-    await chamber.get_power()
-    assert chamber.smart_plug_client.read.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_get_power_recovers_when_boundary_is_missed(kasa_creds, monkeypatch):
-    """If the step loop drifts past a 5-min boundary, the next call still fetches."""
-    chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
-    successful = {"power": 5.0, "voltage": 120.0, "current": 0.04}
-    chamber.smart_plug_client.read = AsyncMock(return_value=successful)
-
-    _pin_time(chamber, monkeypatch, minute=5)
-    await chamber.get_power()
-    assert chamber.smart_plug_client.read.await_count == 1
-
-    # Step loop missed minute=10 entirely, lands at :11. Not on boundary,
-    # but elapsed is 6 min > 5 min interval → fetch via the overdue fallback.
-    _pin_time(chamber, monkeypatch, minute=11)
-    await chamber.get_power()
-    assert chamber.smart_plug_client.read.await_count == 2
+    assert chamber.smart_plug_client.read.await_count == 3

--- a/tests/environments/PlantGrowthChamber/test_get_plant_stats_cadence.py
+++ b/tests/environments/PlantGrowthChamber/test_get_plant_stats_cadence.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import pytest
+
+from environments.PlantGrowthChamber.PlantGrowthChamber import PlantGrowthChamber
+
+UTC = ZoneInfo("Etc/UTC")
+
+
+def _pin_time(chamber, monkeypatch, minute: int):
+    monkeypatch.setattr(
+        chamber, "get_time", lambda: datetime(2026, 5, 6, 12, minute, tzinfo=UTC)
+    )
+
+
+def _stub_cv_client(chamber):
+    """Stub the CV pipeline so tests don't need a running pipeline service."""
+    chamber.cv_client.detect = AsyncMock(return_value={"plant_stats": {}, "state": "s"})
+    chamber.cv_client.propagate = AsyncMock(
+        return_value={"plant_stats": {}, "state": "s"}
+    )
+    chamber._ensure_session = AsyncMock(return_value=None)
+
+
+@pytest.mark.asyncio
+async def test_get_plant_stats_fetches_on_five_minute_boundary(monkeypatch):
+    chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
+    chamber.image = np.zeros((10, 10, 3), dtype=np.uint8)
+    _stub_cv_client(chamber)
+
+    _pin_time(chamber, monkeypatch, minute=5)
+    await chamber.get_plant_stats()
+    assert chamber.cv_client.detect.await_count == 1
+
+    _pin_time(chamber, monkeypatch, minute=6)
+    await chamber.get_plant_stats()
+    assert chamber.cv_client.propagate.await_count == 0
+
+    _pin_time(chamber, monkeypatch, minute=10)
+    await chamber.get_plant_stats()
+    assert chamber.cv_client.propagate.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_plant_stats_recovers_when_boundary_is_missed(monkeypatch):
+    chamber = PlantGrowthChamber(zone="alliance-zone01", timezone="Etc/UTC")
+    chamber.image = np.zeros((10, 10, 3), dtype=np.uint8)
+    _stub_cv_client(chamber)
+
+    _pin_time(chamber, monkeypatch, minute=5)
+    await chamber.get_plant_stats()
+    assert chamber.cv_client.detect.await_count == 1
+
+    _pin_time(chamber, monkeypatch, minute=11)
+    await chamber.get_plant_stats()
+    assert chamber.cv_client.propagate.await_count == 1


### PR DESCRIPTION
Stacked on top of #320 — please merge that one first.

## Summary
Two telemetry cadence fixes that fall out of #320's discovery that the CSV writer (`AsyncRLGlue.log` gates on `env.time.minute % 5 == 0`) and the in-env telemetry fetchers were running on incompatible clocks.

- **`get_power`: drop the 5-min gate entirely.** The plug is now read every step (every minute), matching `get_image`'s cadence. The 5-min throttle was artificial — we already pay per-minute network latency for images, the plug API is comparable, and the CSV writer still only writes every 5 min (just picks up the most recent reading). WandB charts get per-minute granularity for free.
- **`get_plant_stats`: switch from relative `now - last_cv_time >= 5min` to `(minute % 5 == 0) OR overdue`.** Same drift problem #320 fixed for kasa: with the relative gate, the CV fetch lands 1–4 minutes ahead of the CSV write, so every CSV row picks up a slightly stale plant-stats DataFrame. Aligning to wall clock means CSV always sees a fresh CV pass; the elapsed-time fallback covers drift if the step loop ever misses a `:05` boundary.

The CV pipeline is GPU-bound, so I'm keeping it at the 5-minute cadence. Only the kasa fetch is moving to per-minute.

## Test plan
- [x] `pytest tests/environments/PlantGrowthChamber/test_SmartPlugClient.py tests/environments/PlantGrowthChamber/test_SmartPlug_integration.py tests/environments/PlantGrowthChamber/test_get_plant_stats_cadence.py` — 9/9 pass
- [x] New `test_get_plant_stats_fetches_on_five_minute_boundary` and `test_get_plant_stats_recovers_when_boundary_is_missed` lock in the wall-clock alignment
- [x] Rewrote the kasa boundary/drift tests as a single `test_get_power_fetches_every_call` now that the gate is gone
- [ ] Live test on Z1 alongside the rest of the smart-plug rollout (chambers blocked by current flowering-time experiment)
