### PR TITLE
Add E19/P0 constant incubation configs

### DIFF
--- a/experiments/online/E19/P0/Constant1.json
+++ b/experiments/online/E19/P0/Constant1.json
@@ -1,0 +1,18 @@
+{
+    "agent": "Constant1",
+    "problem": "PlantGrowthChamber",
+    "total_steps": 40320,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "environment": {
+            "zone": "alliance-zone01",
+            "timezone": "Etc/GMT-2",
+            "action": "intensity"
+        },
+        "timezone": "Etc/GMT-2",
+        "enforce_night": true,
+        "flash_photography": true,
+        "action_timestep": 720,
+        "constant_action": 1.0
+    }
+}

--- a/experiments/online/E19/P0/Constant2.json
+++ b/experiments/online/E19/P0/Constant2.json
@@ -1,0 +1,18 @@
+{
+    "agent": "Constant2",
+    "problem": "PlantGrowthChamber",
+    "total_steps": 40320,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "environment": {
+            "zone": "alliance-zone02",
+            "timezone": "Etc/GMT-2",
+            "action": "intensity"
+        },
+        "timezone": "Etc/GMT-2",
+        "enforce_night": true,
+        "flash_photography": true,
+        "action_timestep": 720,
+        "constant_action": 1.0
+    }
+}

--- a/experiments/online/E19/P0/Constant3.json
+++ b/experiments/online/E19/P0/Constant3.json
@@ -1,0 +1,18 @@
+{
+    "agent": "Constant3",
+    "problem": "PlantGrowthChamber",
+    "total_steps": 40320,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "environment": {
+            "zone": "alliance-zone03",
+            "timezone": "Etc/GMT-2",
+            "action": "intensity"
+        },
+        "timezone": "Etc/GMT-2",
+        "enforce_night": true,
+        "flash_photography": true,
+        "action_timestep": 720,
+        "constant_action": 1.0
+    }
+}

--- a/experiments/online/E19/P0/Constant4.json
+++ b/experiments/online/E19/P0/Constant4.json
@@ -1,0 +1,18 @@
+{
+    "agent": "Constant4",
+    "problem": "PlantGrowthChamber",
+    "total_steps": 40320,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "environment": {
+            "zone": "alliance-zone04",
+            "timezone": "Etc/GMT-2",
+            "action": "intensity"
+        },
+        "timezone": "Etc/GMT-2",
+        "enforce_night": true,
+        "flash_photography": true,
+        "action_timestep": 720,
+        "constant_action": 1.0
+    }
+}

--- a/experiments/online/E19/P0/Constant5.json
+++ b/experiments/online/E19/P0/Constant5.json
@@ -1,0 +1,18 @@
+{
+    "agent": "Constant5",
+    "problem": "PlantGrowthChamber",
+    "total_steps": 40320,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "environment": {
+            "zone": "alliance-zone05",
+            "timezone": "Etc/GMT-2",
+            "action": "intensity"
+        },
+        "timezone": "Etc/GMT-2",
+        "enforce_night": true,
+        "flash_photography": true,
+        "action_timestep": 720,
+        "constant_action": 1.0
+    }
+}


### PR DESCRIPTION
## Summary
- Add post-refactor E19/P0 configs for alliance-zone01 through alliance-zone05
- Each runs `ConstantAgent` at scalar 1.0 via `PlantGrowthChamber` + `action: intensity`
- Settings mirror E18/P0: flash photography, enforce night, 12 h photoperiod, 28-day envelope

## Test plan
- [x] Configs load via `ExperimentModel` and `getProblem("PlantGrowthChamber")`
- [ ] Deploy one zone smoke test: `python src/main_real.py -e experiments/online/E19/P0/Constant1.json -i 0 --deploy`


Made with [Cursor](https://cursor.com)