### PR TITLE
Restore PlantGrowthChamberIntensity problem

### DIFF
--- a/src/problems/PlantGrowthChamberIntensity.py
+++ b/src/problems/PlantGrowthChamberIntensity.py
@@ -1,0 +1,26 @@
+from PyExpUtils.collection.Collector import Collector
+
+from environments.PlantGrowthChamber.factory import create_plant_growth_chamber
+from environments.PlantGrowthChamber.specs import ACTION_SPECS, create_observation_spec
+from experiment.ExperimentModel import ExperimentModel
+from problems.BasePlantGrowthChamberAsyncProblem import (
+    BasePlantGrowthChamberAsyncProblem,
+)
+
+
+class PlantGrowthChamberIntensity(BasePlantGrowthChamberAsyncProblem):
+    def __init__(self, exp: ExperimentModel, idx: int, collector: Collector):
+        super().__init__(exp, idx, collector)
+
+        self.env_params.setdefault("action", "intensity")
+
+        observation_name = self.env_params.get("observation", "scalar")
+        action_name = self.env_params["action"]
+        action_spec = ACTION_SPECS[action_name]
+        observation_spec = create_observation_spec(
+            observation_name, action_spec, self.env_params
+        )
+
+        self.env = create_plant_growth_chamber(**self.env_params)
+        self.observations = observation_spec.shape
+        self.actions = action_spec.n_actions


### PR DESCRIPTION
## Summary
- Restores `src/problems/PlantGrowthChamberIntensity.py` that was deleted in the factory refactor (`fd08bd10`)
- E18/P1 experiment configs reference this problem by name; without it any fresh container start would fail with `ImportError`
- The new file simply defaults the `action` spec to `"intensity"` while delegating all env creation to the existing factory + specs machinery
- **No change to E18 or E19 running behaviour** — purely additive

## Test plan
- [ ] Verify `python -c "from problems.PlantGrowthChamberIntensity import PlantGrowthChamberIntensity"` imports cleanly
- [ ] Confirm E18/P1 configs still resolve when loaded via `getProblem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)