### PR TITLE
Add IncubatorAgent for constant-PPFD incubation experiments

### DIFF
--- a/src/algorithms/IncubatorAgent.py
+++ b/src/algorithms/IncubatorAgent.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, Tuple
+
+import numpy as np
+from PyExpUtils.collection.Collector import Collector
+
+from algorithms.BaseAgent import BaseAgent
+from utils.checkpoint import checkpointable
+from utils.constants import BALANCED_ACTION_100
+
+
+@checkpointable(("steps",))
+class IncubatorAgent(BaseAgent):
+    """Constant-PPFD incubation agent.
+
+    Outputs a balanced PPFD6 action at a fixed PPFD level. Night/dawn/dusk
+    enforcement is handled upstream by PlantGrowthChamberAsyncAgentWrapper,
+    so this agent only needs to supply the daytime light level.
+
+    Params
+    ------
+    incubation_ppfd : float
+        Target PPFD for daytime light (0-100).  Defaults to 100.
+    """
+
+    def __init__(
+        self,
+        observations: Tuple[int, ...],
+        actions: int,
+        params: Dict,
+        collector: Collector,
+        seed: int,
+    ):
+        super().__init__(observations, actions, params, collector, seed)
+        self.steps = 0
+        incubation_ppfd = float(params.get("incubation_ppfd", 100.0))
+        self.action = BALANCED_ACTION_100 * (incubation_ppfd / 100.0)
+
+    def policy(self, observation: np.ndarray, deterministic: bool = True) -> np.ndarray:
+        return self.action
+
+    def start(
+        self, observation: np.ndarray, extra: Dict[str, Any]
+    ) -> Tuple[np.ndarray, Dict[str, Any]]:
+        return self.action, {}
+
+    def step(
+        self, reward: float, observation: np.ndarray | None, extra: Dict[str, Any]
+    ) -> Tuple[np.ndarray, Dict[str, Any]]:
+        self.steps += 1
+        return self.action, {}
+
+    def end(self, reward: float, extra: Dict[str, Any]) -> Dict[str, Any]:
+        return {}

--- a/src/algorithms/registry.py
+++ b/src/algorithms/registry.py
@@ -3,6 +3,7 @@ from typing import Type
 from algorithms.BaseAgent import BaseAgent
 from algorithms.BernoulliAgent import BernoulliAgent
 from algorithms.ConstantAgent import ConstantAgent
+from algorithms.IncubatorAgent import IncubatorAgent
 from algorithms.ContinuousRandomAgent import ContinuousRandomAgent
 from algorithms.ContinuousRandomSimplexAgent import ContinuousRandomSimplexAgent
 from algorithms.DirichletAgent import DirichletAgent
@@ -72,6 +73,9 @@ def getAgent(name) -> Type[BaseAgent]:
     """
     if name == "SoftmaxAC":
         return SoftmaxAC
+
+    if name.startswith("Incubator"):
+        return IncubatorAgent
 
     if name.startswith("Constant"):
         return ConstantAgent


### PR DESCRIPTION
## Summary
- Adds `src/algorithms/IncubatorAgent.py`: a `BaseAgent` that outputs a balanced PPFD6 action scaled to a configurable `incubation_ppfd` (0–100, default 100 ppfd)
- Night / dawn / dusk enforcement is left to the existing `PlantGrowthChamberAsyncAgentWrapper` — the agent only expresses the daytime intensity
- Registered in `algorithms/registry.py` so any agent name prefixed with `"Incubator"` (e.g. `"Incubator4"`) resolves to this class
- **No change to E18 or E19** — additive only

## Test plan
- [ ] `from algorithms.IncubatorAgent import IncubatorAgent` imports cleanly
- [ ] `getAgent("Incubator4")` returns `IncubatorAgent`
- [ ] Confirm `incubation_ppfd=100` produces `BALANCED_ACTION_100` action

🤖 Generated with [Claude Code](https://claude.com/claude-code)