### PR TITLE
Lower safe_minimum PPFD values in calibration.json

### DIFF
--- a/src/environments/PlantGrowthChamber/configs/calibration.json
+++ b/src/environments/PlantGrowthChamber/configs/calibration.json
@@ -16,11 +16,11 @@
         "far_red": 21.636228499999987
     },
     "safe_minimum": {
-        "blue": 5.0,
-        "cool_white": 5.0,
-        "warm_white": 5.0,
-        "orange_red": 4.0,
-        "red": 5.0,
+        "blue": 1.0,
+        "cool_white": 1.0,
+        "warm_white": 1.0,
+        "orange_red": 2.0,
+        "red": 1.0,
         "far_red": 0.6679889999999996
     }
 }


### PR DESCRIPTION
## Summary
Syncs `src/environments/PlantGrowthChamber/configs/calibration.json` with the updated calibration from `plant-data-collection`.

| Channel | Before | After |
|---------|--------|-------|
| blue | 5.0 | 1.0 |
| cool_white | 5.0 | 1.0 |
| warm_white | 5.0 | 1.0 |
| orange_red | 4.0 | 2.0 |
| red | 5.0 | 1.0 |

`maximum`, `safe_maximum`, and `far_red` values are unchanged.

## Test plan
- [ ] Confirm lightbar calibration still loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)