### PR TITLE
Add __getstate__/__setstate__ to BaseAsyncAgent for checkpointing

### DIFF
--- a/src/utils/RlGlue/agent.py
+++ b/src/utils/RlGlue/agent.py
@@ -28,6 +28,14 @@ class BaseAgent(RlGlueBaseAgent):
 
 
 class BaseAsyncAgent:
+    _init_args: tuple[Any, ...]
+
+    def __getstate__(self):
+        return {"__args": self._init_args}
+
+    def __setstate__(self, state):
+        self.__init__(*state["__args"])  # type: ignore[misc]
+
     @abstractmethod
     async def start(
         self,


### PR DESCRIPTION
## Summary
Adds `__getstate__` / `__setstate__` to `BaseAsyncAgent` using a `_init_args` convention, ported from `plant-data-collection`.

Subclasses that store their constructor arguments in `self._init_args` (e.g. `PlantGrowthChamberAsyncAgentWrapper`) can now be pickled and restored by the standard checkpoint machinery without needing their own serialisation boilerplate.

No behaviour change for existing agents — the methods are only invoked when pickling.

## Test plan
- [ ] Confirm existing checkpoint round-trip still works for E18/E19 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)