### PR TITLE
Add on-device fallback lighting schedule for lightbars

### DIFF
--- a/api/lightbar/README.md
+++ b/api/lightbar/README.md
@@ -22,3 +22,27 @@ ssh mitacs-zone8 -t "cd ~/Desktop/lightbar && docker compose pull && docker comp
 curl http://mitacs-zone8.ccis.ualberta.ca:8080/action -X PUT -H "Content-Type: application/json" -d '{"array": [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]}'
 curl http://mitacs-zone8.ccis.ualberta.ca:8080/action/latest
 ```
+
+## On-device fallback schedule
+
+The device can enforce a time-of-day schedule on its own so the photoperiod
+still turns on/off on time when the network to the control host drops. Behaviour
+is *transition-only*: each entry's calibrated action is applied once when its
+`HH:MM` is crossed (in the supplied timezone) and held until the next entry, so
+live `PUT /action` calls take over seamlessly during normal operation. The
+schedule is persisted (`/app/schedule.json`, bind-mounted) and reloaded on
+restart. The agent wrapper sets this automatically at start
+(`fallback_schedule`, default on): lights on at 08:59 at 40 PPFD, off at 21:00.
+
+```bash
+# Set/replace the schedule (action is the calibrated [2,6] array, same as /action)
+curl http://mitacs-zone8.ccis.ualberta.ca:8080/schedule -X PUT -H "Content-Type: application/json" \
+  -d '{"timezone": "Etc/GMT-2", "entries": [
+        {"time": "08:59", "action": [[0.1,0.1,0.1,0,0.1,0],[0.1,0.1,0.1,0,0.1,0]]},
+        {"time": "21:00", "action": [[0,0,0,0,0,0],[0,0,0,0,0,0]]}]}'
+curl http://mitacs-zone8.ccis.ualberta.ca:8080/schedule          # inspect
+curl http://mitacs-zone8.ccis.ualberta.ca:8080/schedule -X DELETE # clear
+```
+
+**Redeploy required:** the schedule feature is inert until the device code is
+updated. Apply the Update steps above to every active Pi.

--- a/api/lightbar/app/main.py
+++ b/api/lightbar/app/main.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
+from contextlib import asynccontextmanager
 from functools import lru_cache
 from typing import List
+from zoneinfo import ZoneInfoNotFoundError
 
 import numpy as np
 from fastapi import Depends, FastAPI, Response
@@ -9,9 +11,9 @@ from pydantic import BaseModel
 from typing_extensions import Annotated
 
 from .lightbar import Lightbar
+from .scheduler import Scheduler
 from .zones import ZONES
 
-app = FastAPI()
 zone = ZONES.get(os.getenv("ZONE", "mitacs-zone2"))
 
 
@@ -19,9 +21,35 @@ class Action(BaseModel):
     array: List[List[float]]
 
 
+class ScheduleEntry(BaseModel):
+    time: str
+    action: List[List[float]]
+
+
+class ScheduleBody(BaseModel):
+    timezone: str
+    entries: List[ScheduleEntry]
+
+
 @lru_cache(maxsize=None)
 def get_lightbar():
     return Lightbar(zone)
+
+
+scheduler = Scheduler(get_lightbar)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler.load()
+    scheduler.start()
+    try:
+        yield
+    finally:
+        scheduler.stop()
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.put("/action", response_class=Response)
@@ -37,6 +65,32 @@ def get_current_action(lightbar: Lightbar = Depends(get_lightbar)):
         if lightbar.safe_action is not None
         else None,
     }
+
+
+@app.put("/schedule", response_class=Response)
+def put_schedule(body: ScheduleBody):
+    """Replace the on-device fallback schedule (clears old + sets new)."""
+    entries = [entry.model_dump() for entry in body.entries]
+    try:
+        scheduler.set(body.timezone, entries)
+    except ZoneInfoNotFoundError:
+        return Response(
+            content=f"Unknown timezone: {body.timezone}",
+            media_type="text/plain",
+            status_code=422,
+        )
+    except ValueError as e:
+        return Response(content=str(e), media_type="text/plain", status_code=422)
+
+
+@app.delete("/schedule", response_class=Response)
+def delete_schedule():
+    scheduler.clear()
+
+
+@app.get("/schedule")
+def get_schedule():
+    return scheduler.snapshot()
 
 
 @app.post("/reset", response_class=Response)

--- a/api/lightbar/app/scheduler.py
+++ b/api/lightbar/app/scheduler.py
@@ -92,7 +92,9 @@ def entries_due_between(
 class Scheduler:
     """Holds the current schedule and applies it on a background daemon thread."""
 
-    def __init__(self, get_lightbar, schedule_path=SCHEDULE_PATH, tick_seconds=TICK_SECONDS):
+    def __init__(
+        self, get_lightbar, schedule_path=SCHEDULE_PATH, tick_seconds=TICK_SECONDS
+    ):
         self._get_lightbar = get_lightbar
         self._schedule_path = Path(schedule_path)
         self._tick_seconds = tick_seconds
@@ -235,4 +237,6 @@ class Scheduler:
             self._get_lightbar().step(np.array(entry["action"]))
             logger.info("scheduler applied entry time=%s", entry.get("time"))
         except Exception:
-            logger.exception("scheduler failed to apply entry time=%s", entry.get("time"))
+            logger.exception(
+                "scheduler failed to apply entry time=%s", entry.get("time")
+            )

--- a/api/lightbar/app/scheduler.py
+++ b/api/lightbar/app/scheduler.py
@@ -1,0 +1,238 @@
+"""On-device fallback lighting schedule.
+
+The control host normally drives the lightbar every minute via PUT /action. When
+the network between the host and this Pi drops, those calls stop arriving and the
+photoperiod transitions are missed. This module lets the device enforce a small
+time-of-day schedule on its own so the lights still turn on/off on time without
+the network.
+
+Behaviour is *transition-only*: an entry is applied once when its HH:MM is
+crossed, and the device holds that action until the next entry. It does not
+re-assert between transitions, so live PUT /action calls take over seamlessly
+during normal operation.
+
+The container clock is UTC, so a schedule always carries an explicit timezone and
+all comparisons happen in that timezone.
+"""
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# compose.yml bind-mounts .:/app, so this file survives `docker compose restart`.
+SCHEDULE_PATH = Path("/app/schedule.json")
+TICK_SECONDS = 20
+
+
+def _parse_hhmm(value: str) -> tuple[int, int]:
+    hour, minute = value.split(":")
+    hour, minute = int(hour), int(minute)
+    if not (0 <= hour < 24 and 0 <= minute < 60):
+        raise ValueError(f"time out of range: {value}")
+    return hour, minute
+
+
+def _fire_datetime_at_or_before(entry: dict, ref_dt: datetime) -> datetime:
+    """Most recent datetime <= ref_dt whose time-of-day matches entry['time'].
+
+    Anchoring each entry to an actual date (today if its HH:MM has already passed,
+    otherwise yesterday) makes both helpers below handle the midnight wrap without
+    special cases.
+    """
+    hour, minute = _parse_hhmm(entry["time"])
+    # ref_dt is tz-aware; .replace keeps the ZoneInfo, which recomputes the UTC
+    # offset for the new wall time, so the instant comparisons in the callers are
+    # correct across DST. (A wall time inside a DST gap/overlap resolves to
+    # ZoneInfo's default fold, which is fine for firing a transition.)
+    candidate = ref_dt.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate > ref_dt:
+        candidate -= timedelta(days=1)
+    return candidate
+
+
+def active_entry(entries: list[dict], now_dt: datetime) -> dict | None:
+    """Return the entry currently in effect (most recent at-or-before now_dt).
+
+    Wraps past midnight; returns None for an empty schedule. Used to restore the
+    correct state when a schedule is (re)set or loaded after a container restart.
+    """
+    if not entries:
+        return None
+    return max(entries, key=lambda e: _fire_datetime_at_or_before(e, now_dt))
+
+
+def entries_due_between(
+    entries: list[dict], last_dt: datetime | None, now_dt: datetime
+) -> list[dict]:
+    """Entries whose HH:MM falls in (last_dt, now_dt], in fire order.
+
+    Assumes now_dt - last_dt < 24h (true for the short tick), so each entry fires
+    at most once per window. Handles the midnight wrap via the date anchoring in
+    _fire_datetime_at_or_before.
+    """
+    if not entries or last_dt is None or now_dt <= last_dt:
+        return []
+    due = []
+    for entry in entries:
+        fire = _fire_datetime_at_or_before(entry, now_dt)
+        if last_dt < fire <= now_dt:
+            due.append((fire, entry))
+    due.sort(key=lambda item: item[0])
+    return [entry for _, entry in due]
+
+
+class Scheduler:
+    """Holds the current schedule and applies it on a background daemon thread."""
+
+    def __init__(self, get_lightbar, schedule_path=SCHEDULE_PATH, tick_seconds=TICK_SECONDS):
+        self._get_lightbar = get_lightbar
+        self._schedule_path = Path(schedule_path)
+        self._tick_seconds = tick_seconds
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.timezone: str | None = None
+        self.entries: list[dict] = []
+        self.last_check: datetime | None = None
+        self.last_fired: datetime | None = None
+        # When True, the next tick reapplies the currently-active entry instead of
+        # only firing crossed transitions, so the device snaps to the correct state
+        # after a reboot mid-outage. Armed only by load() (restart recovery), NOT by
+        # a live set(): overriding the action a connected agent just chose would be
+        # wrong; the next transition handles a live set going forward.
+        self._reapply_pending = False
+
+    # -- schedule management --
+    def set(self, timezone: str, entries: list[dict], reapply: bool = False) -> None:
+        """Replace the schedule (clears old + sets new) and persist it.
+
+        ``reapply`` arms an immediate snap to the currently-active entry on the next
+        tick; reserved for load()/restart recovery, off for live updates.
+        """
+        ZoneInfo(timezone)  # validate; raises on unknown tz
+        for entry in entries:
+            _parse_hhmm(entry["time"])  # validate; raises on bad time
+        with self._lock:
+            self.timezone = timezone
+            self.entries = entries
+            self.last_fired = None
+            self._reapply_pending = reapply
+            self._persist_locked()
+
+    def clear(self) -> None:
+        with self._lock:
+            self.timezone = None
+            self.entries = []
+            self.last_check = None
+            self.last_fired = None
+            self._reapply_pending = False
+            try:
+                self._schedule_path.unlink(missing_ok=True)
+            except OSError:
+                logger.exception("failed to remove schedule file")
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "timezone": self.timezone,
+                "entries": self.entries,
+                "last_check": self.last_check.isoformat() if self.last_check else None,
+                "last_fired": self.last_fired.isoformat() if self.last_fired else None,
+            }
+
+    # -- persistence --
+    def _persist_locked(self) -> None:
+        # Write to a sibling temp file then atomically rename, so a crash mid-write
+        # can't leave a truncated schedule.json that fails to parse on restart.
+        try:
+            tmp = self._schedule_path.with_name(self._schedule_path.name + ".tmp")
+            tmp.write_text(
+                json.dumps({"timezone": self.timezone, "entries": self.entries})
+            )
+            os.replace(tmp, self._schedule_path)
+        except OSError:
+            logger.exception("failed to persist schedule file")
+
+    def load(self) -> None:
+        try:
+            data = json.loads(self._schedule_path.read_text())
+        except FileNotFoundError:
+            return
+        except (OSError, ValueError):
+            logger.exception("failed to load schedule file")
+            return
+        timezone = data.get("timezone")
+        entries = data.get("entries") or []
+        if timezone and entries:
+            try:
+                self.set(timezone, entries, reapply=True)
+            except Exception:
+                logger.exception("failed to apply loaded schedule")
+
+    # -- background loop --
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="lightbar-scheduler", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self._tick()
+            except Exception:
+                logger.exception("scheduler tick failed")
+            self._stop.wait(self._tick_seconds)
+
+    def _tick(self, now: datetime | None = None) -> None:
+        with self._lock:
+            timezone = self.timezone
+            entries = list(self.entries)
+            last_check = self.last_check
+            # Consume the reapply flag under the same lock as the read, so a set()
+            # that lands while this tick runs re-arms it for the next tick rather
+            # than having its request cleared by our tail update.
+            reapply = self._reapply_pending
+            self._reapply_pending = False
+        if not timezone or not entries:
+            return
+        if now is None:
+            now = datetime.now(ZoneInfo(timezone))
+
+        if reapply:
+            entry = active_entry(entries, now)
+            to_fire = [entry] if entry is not None else []
+        else:
+            to_fire = entries_due_between(entries, last_check, now)
+
+        for entry in to_fire:
+            self._apply(entry)
+
+        with self._lock:
+            self.last_check = now
+            if to_fire:
+                self.last_fired = now
+
+    def _apply(self, entry: dict) -> None:
+        try:
+            self._get_lightbar().step(np.array(entry["action"]))
+            logger.info("scheduler applied entry time=%s", entry.get("time"))
+        except Exception:
+            logger.exception("scheduler failed to apply entry time=%s", entry.get("time"))

--- a/api/lightbar/tests/test_main.py
+++ b/api/lightbar/tests/test_main.py
@@ -51,9 +51,7 @@ def test_schedule_round_trip():
 
 
 def test_schedule_bad_timezone():
-    response = client.put(
-        "/schedule", json={"timezone": "Not/AZone", "entries": []}
-    )
+    response = client.put("/schedule", json={"timezone": "Not/AZone", "entries": []})
     assert response.status_code == 422
 
 

--- a/api/lightbar/tests/test_main.py
+++ b/api/lightbar/tests/test_main.py
@@ -33,6 +33,46 @@ def test_action_latest():
     }
 
 
+def test_schedule_round_trip():
+    entries = [
+        {"time": "08:59", "action": (np.ones((2, 6)) * 0.1).tolist()},
+        {"time": "21:00", "action": np.zeros((2, 6)).tolist()},
+    ]
+    response = client.put(
+        "/schedule", json={"timezone": "Etc/GMT-2", "entries": entries}
+    )
+    assert response.status_code == 200
+
+    response = client.get("/schedule")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["timezone"] == "Etc/GMT-2"
+    assert data["entries"] == entries
+
+
+def test_schedule_bad_timezone():
+    response = client.put(
+        "/schedule", json={"timezone": "Not/AZone", "entries": []}
+    )
+    assert response.status_code == 422
+
+
+def test_schedule_delete():
+    client.put(
+        "/schedule",
+        json={
+            "timezone": "Etc/GMT-2",
+            "entries": [{"time": "08:59", "action": np.zeros((2, 6)).tolist()}],
+        },
+    )
+    response = client.delete("/schedule")
+    assert response.status_code == 200
+
+    data = client.get("/schedule").json()
+    assert data["timezone"] is None
+    assert data["entries"] == []
+
+
 def test_action():
     response = client.put("/action", json={"array": np.ones((2, 6)).tolist()})
     assert response.status_code == 200

--- a/api/lightbar/tests/test_scheduler.py
+++ b/api/lightbar/tests/test_scheduler.py
@@ -1,0 +1,120 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import numpy as np
+
+from ..app.scheduler import Scheduler, active_entry, entries_due_between
+
+TZ = "Etc/GMT-2"
+
+ON = {"time": "08:59", "action": (np.ones((2, 6)) * 0.1).tolist()}
+OFF = {"time": "21:00", "action": np.zeros((2, 6)).tolist()}
+ENTRIES = [ON, OFF]
+
+
+def dt(hour, minute, day=1):
+    return datetime(2026, 6, day, hour, minute, tzinfo=ZoneInfo(TZ))
+
+
+class RecorderLightbar:
+    def __init__(self):
+        self.actions = []
+
+    def step(self, action):
+        self.actions.append(np.asarray(action).tolist())
+
+
+def test_active_entry():
+    assert active_entry(ENTRIES, dt(10, 0)) is ON
+    assert active_entry(ENTRIES, dt(22, 0)) is OFF
+    # Before the first ON of the day -> previous day's OFF is still in effect.
+    assert active_entry(ENTRIES, dt(3, 0)) is OFF
+    assert active_entry([], dt(10, 0)) is None
+
+
+def test_entries_due_between_fires_once_on_crossing():
+    assert entries_due_between(ENTRIES, dt(8, 58), dt(9, 0)) == [ON]
+    assert entries_due_between(ENTRIES, dt(20, 59), dt(21, 1)) == [OFF]
+
+
+def test_entries_due_between_excludes_already_fired_boundary():
+    # The interval is half-open (last, now]; an entry exactly at last already fired.
+    assert entries_due_between(ENTRIES, dt(8, 59), dt(9, 0)) == []
+
+
+def test_entries_due_between_no_crossing():
+    assert entries_due_between(ENTRIES, dt(10, 0), dt(10, 5)) == []
+
+
+def test_entries_due_between_midnight_wrap():
+    midnight = [{"time": "00:00", "action": np.zeros((2, 6)).tolist()}]
+    due = entries_due_between(midnight, dt(23, 50, day=1), dt(0, 10, day=2))
+    assert due == midnight
+
+
+def test_entries_due_between_handles_missing_last():
+    assert entries_due_between(ENTRIES, None, dt(10, 0)) == []
+
+
+def test_set_does_not_reapply_active_entry(tmp_path):
+    # A live set() must not override the action a connected agent just chose;
+    # only transitions fire going forward.
+    recorder = RecorderLightbar()
+    scheduler = Scheduler(lambda: recorder, schedule_path=tmp_path / "schedule.json")
+    scheduler.set(TZ, ENTRIES)
+
+    scheduler._tick(now=dt(10, 0))
+
+    assert recorder.actions == []
+    assert scheduler.snapshot()["timezone"] == TZ
+
+
+def test_load_reapplies_active_entry_on_first_tick(tmp_path):
+    # Restart recovery: a loaded schedule snaps to the currently-active entry.
+    path = tmp_path / "schedule.json"
+    Scheduler(lambda: RecorderLightbar(), schedule_path=path).set(TZ, ENTRIES)
+
+    recorder = RecorderLightbar()
+    scheduler = Scheduler(lambda: recorder, schedule_path=path)
+    scheduler.load()
+
+    scheduler._tick(now=dt(10, 0))
+
+    assert recorder.actions == [ON["action"]]
+    assert scheduler.snapshot()["last_fired"] is not None
+
+
+def test_transition_fires_without_reapply(tmp_path):
+    recorder = RecorderLightbar()
+    scheduler = Scheduler(lambda: recorder, schedule_path=tmp_path / "schedule.json")
+    scheduler.set(TZ, ENTRIES)
+
+    scheduler._tick(now=dt(10, 0))  # establishes last_check, no reapply
+    scheduler._tick(now=dt(21, 1))  # crosses 21:00 -> OFF
+
+    assert recorder.actions == [OFF["action"]]
+
+
+def test_clear(tmp_path):
+    path = tmp_path / "schedule.json"
+    scheduler = Scheduler(lambda: RecorderLightbar(), schedule_path=path)
+    scheduler.set(TZ, ENTRIES)
+    assert path.exists()
+
+    scheduler.clear()
+
+    assert scheduler.snapshot()["timezone"] is None
+    assert scheduler.snapshot()["entries"] == []
+    assert not path.exists()
+
+
+def test_persistence_survives_reload(tmp_path):
+    path = tmp_path / "schedule.json"
+    Scheduler(lambda: RecorderLightbar(), schedule_path=path).set(TZ, ENTRIES)
+
+    reloaded = Scheduler(lambda: RecorderLightbar(), schedule_path=path)
+    reloaded.load()
+
+    snapshot = reloaded.snapshot()
+    assert snapshot["timezone"] == TZ
+    assert snapshot["entries"] == ENTRIES

--- a/src/algorithms/PlantGrowthChamberAsyncAgentWrapper.py
+++ b/src/algorithms/PlantGrowthChamberAsyncAgentWrapper.py
@@ -16,6 +16,12 @@ from utils.RlGlue.agent import AsyncAgentWrapper
 
 logger = logging.getLogger("plant_rl.PlantGrowthChamberAsyncAgentWrapper")
 
+# Single source of truth for the flash/fallback photoperiod boundaries (local
+# time). Used by both the live flash-photography enforcement and the on-device
+# fallback schedule so the two can never drift apart.
+PHOTOPERIOD_ON = (8, 59)  # lights on; 1-min flash at BALANCED_ACTION_40
+PHOTOPERIOD_OFF = (21, 0)  # lights off
+
 
 class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
     def __init__(self, agent: BaseAgent, env=None):
@@ -27,6 +33,10 @@ class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
         self.agent_started = False
         self.enforce_night = agent.params.get("enforce_night", True)
         self.flash_photography = agent.params.get("flash_photography", False)
+        # Push an on-device fallback schedule to the lightbar at agent start so the
+        # photoperiod still turns on/off on time if the network to the device drops.
+        self.fallback_schedule = agent.params.get("fallback_schedule", True)
+        self._fallback_set = False
         # In flash mode the daytime block starts at 09:00; in normal mode dawn
         # finishes at 09:30 and the agent is first polled then.
         self.poll_at_minute = 0 if self.flash_photography else 30
@@ -118,6 +128,7 @@ class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
         if extra is None:
             extra = {}
         self.update_time_from_extra(extra)
+        await self.maybe_set_fallback_schedule()
 
         if not self.maybe_enforce_action():
             logger.debug(f"Starting agent at {self.env_local_time}")
@@ -130,6 +141,35 @@ class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
                 self.env.update_action_trace(self.last_action_info[0])
         return self.last_action_info
 
+    async def maybe_set_fallback_schedule(self) -> None:
+        """Push the on-device fallback schedule to the lightbar once, at start.
+
+        Mirrors the flash-photography photoperiod as a coarse square wave: lights
+        on at 08:59 (40 PPFD) and off at 21:00, in the configured timezone. The
+        device fires these transitions itself, guaranteeing the photoperiod even
+        when the network to the device is down.
+        """
+        if not self.fallback_schedule or self._fallback_set:
+            return
+        if self.env is None or not hasattr(self.env, "put_schedule"):
+            return
+        on_h, on_m = PHOTOPERIOD_ON
+        off_h, off_m = PHOTOPERIOD_OFF
+        try:
+            # Only mark as set once the device actually accepted the schedule,
+            # otherwise retry on the next step (a transient network drop at start
+            # must not permanently disable the fallback).
+            delivered = await self.env.put_schedule(
+                [
+                    (f"{on_h:02d}:{on_m:02d}", BALANCED_ACTION_40),
+                    (f"{off_h:02d}:{off_m:02d}", np.zeros(6)),
+                ]
+            )
+            if delivered:
+                self._fallback_set = True
+        except Exception:
+            logger.exception("Failed to set fallback lighting schedule")
+
     def maybe_enforce_flash_photography_action(self) -> bool:
         """Flash-photography override of maybe_enforce_action.
 
@@ -141,11 +181,10 @@ class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
         assert self.env_local_time is not None, (
             "Environment local time must be set before flash-mode enforcement."
         )
-        h = self.env_local_time.hour
-        m = self.env_local_time.minute
-        if 9 <= h <= 20:
+        now = (self.env_local_time.hour, self.env_local_time.minute)
+        if PHOTOPERIOD_ON < now < PHOTOPERIOD_OFF:
             return False
-        if h == 8 and m == 59:
+        if now == PHOTOPERIOD_ON:
             self.last_action_info = (BALANCED_ACTION_40, {})
             logger.debug(f"Flash photography capture at {self.env_local_time}")
             return True
@@ -179,6 +218,8 @@ class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
         self, reward: float, observation: Any, extra: dict[str, Any]
     ) -> tuple[Any, dict[str, Any]]:
         self.update_time_from_extra(extra)
+        # Retry until the device accepts it; a no-op once _fallback_set is True.
+        await self.maybe_set_fallback_schedule()
 
         if self.maybe_enforce_action():
             return self.last_action_info
@@ -231,6 +272,7 @@ class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
         state = {
             "__args": (self.agent, self.env),
             "agent_started": self.agent_started,
+            "fallback_set": self._fallback_set,
             "last_action_time": self.last_action_time.timestamp()
             if self.last_action_time
             else None,
@@ -245,6 +287,7 @@ class PlantGrowthChamberAsyncAgentWrapper(AsyncAgentWrapper):
     def __setstate__(self, state):
         self.__init__(*state["__args"])
         self.agent_started = state.get("agent_started", False)
+        self._fallback_set = state.get("fallback_set", False)
 
         # Restore datetime objects from timestamps
         if state.get("last_action_time") is not None:

--- a/src/environments/PlantGrowthChamber/MockPlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/MockPlantGrowthChamber.py
@@ -128,6 +128,12 @@ class MockPlantGrowthChamber(PlantGrowthChamber):
         logger.debug(f"action: {action}")
         self.last_action = action
 
+    async def put_schedule(self, entries) -> bool:
+        # No hardware/network in offline replay; report success so the wrapper
+        # marks the fallback set and does not retry every step.
+        logger.debug(f"put_schedule: {entries}")
+        return True
+
     async def sleep_until(self, wake_time: datetime):
         while (
             self.time_index + 1 < len(self.unique_wall_times)

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -340,7 +340,9 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             logger.info(f"Set fallback schedule on {schedule_url}: {payload_entries}")
             return True
         except Exception:
-            logger.exception(f"Error: failed to set fallback schedule on {schedule_url}")
+            logger.exception(
+                f"Error: failed to set fallback schedule on {schedule_url}"
+            )
             return False
 
     async def start(self):

--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -278,16 +278,18 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             )
             # Keep previous image if available, otherwise this side will be missing
 
-    async def put_action(self, action):
-        """Send action to the lightbar using aiohttp with retry logic"""
-        last_calibrated_action = (
+    def calibrate_action(self, action):
+        """Calibrate a raw action and clip it to the lightbar's [.., 1] range."""
+        calibrated = (
             self.zone.calibration.get_calibrated_action(action)
             if self.zone.calibration
             else action
         )
+        return np.clip(calibrated, None, 1)
 
-        # clip action to have max value 1
-        last_calibrated_action = np.clip(last_calibrated_action, None, 1)
+    async def put_action(self, action):
+        """Send action to the lightbar using aiohttp with retry logic"""
+        last_calibrated_action = self.calibrate_action(action)
         action_to_send = np.tile(last_calibrated_action, (2, 1))
 
         try:
@@ -311,6 +313,35 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
                     f"Warning: {self.zone.lightbar_url} after retries, last action was identical",
                     exc_info=True,
                 )
+
+    async def put_schedule(self, entries) -> bool:
+        """Push an on-device fallback schedule to the lightbar.
+
+        ``entries`` is a list of ``(time_str "HH:MM", raw 6-channel action)``. Each
+        action is calibrated and tiled exactly like ``put_action`` so the device
+        stores the same calibrated ``[2, 6]`` array it would receive live. Returns
+        True when the schedule was delivered (or there is nothing to send), False
+        when the PUT failed, so the caller can retry instead of assuming success.
+        Failures are logged, never raised (same posture as ``put_action``).
+        """
+        schedule_url = self.zone.schedule_url
+        if not schedule_url:
+            return True
+        payload_entries = []
+        for time_str, action in entries:
+            calibrated = self.calibrate_action(np.asarray(action, dtype=float))
+            payload_entries.append(
+                {"time": time_str, "action": np.tile(calibrated, (2, 1)).tolist()}
+            )
+        body = {"timezone": self.timezone, "entries": payload_entries}
+        try:
+            session = await self._ensure_action_session()
+            await session.put(schedule_url, json=body, timeout=5)
+            logger.info(f"Set fallback schedule on {schedule_url}: {payload_entries}")
+            return True
+        except Exception:
+            logger.exception(f"Error: failed to set fallback schedule on {schedule_url}")
+            return False
 
     async def start(self):
         logger.debug(f"Local time: {self.get_local_time()}. Step 0")

--- a/src/environments/PlantGrowthChamber/zones.py
+++ b/src/environments/PlantGrowthChamber/zones.py
@@ -16,6 +16,17 @@ class Zone:
     calibration: Calibration | None
     smart_plug_host: str | None = None
 
+    @property
+    def schedule_url(self) -> str | None:
+        """The lightbar's ``/schedule`` endpoint, derived from its ``/action`` URL.
+
+        Returns None when there is no lightbar URL or it does not follow the
+        ``.../action`` convention, so callers skip rather than POST to a wrong URL.
+        """
+        if not self.lightbar_url or not self.lightbar_url.endswith("/action"):
+            return None
+        return self.lightbar_url[: -len("/action")] + "/schedule"
+
 
 def deserialize_zone(zone: dict) -> Zone:
     calibration_data = zone.get("calibration")


### PR DESCRIPTION
## Why

A network switch replacement in CCIS intermittently cut connectivity between the control host (RL agent) and the lightbar Raspberry Pis. When the agent can't reach a lightbar, the per-minute `PUT /action` calls stop and the photoperiod fails to turn on/off on time, corrupting the experiment.

Give each lightbar a small **time-of-day schedule it enforces itself**, independent of the network. The agent wrapper clears any old schedule and sets a fallback that guarantees — at the very least — lights **on at 08:59 (40 PPFD)** and **off at 21:00** (in the configured timezone). Because the outage breaks the link to the device, the schedule logic runs on the Pi; the wrapper only configures it.

## What

**Lightbar device API (`api/lightbar/`)**
- New `Scheduler` (`app/scheduler.py`): background daemon, **transition-only** firing (an entry is applied once when its `HH:MM` is crossed, held until the next entry, so live `PUT /action` takes over during normal operation), **atomic** JSON persistence (`/app/schedule.json`, bind-mounted), and **reapply-on-load** so a reboot mid-outage snaps to the correct state.
- `PUT` / `DELETE` / `GET /schedule` endpoints wired via a FastAPI `lifespan`.

**Control side**
- `PlantGrowthChamber.put_schedule` calibrates + tiles entries exactly like `put_action` and PUTs to the zone's `schedule_url`; returns delivery success.
- `Zone.schedule_url` derives the endpoint from `lightbar_url` (only when it ends in `/action`), localizing the convention.
- `PlantGrowthChamberAsyncAgentWrapper` pushes the fallback at agent start (default on via `fallback_schedule`), **retrying each step until the device confirms** so a startup network blip can't silently disable it.
- Photoperiod boundaries centralized as `PHOTOPERIOD_ON/OFF`, shared by the flash-photography enforcement and the fallback (single source of truth).
- `MockPlantGrowthChamber.put_schedule` is a no-op so offline/replay runs do no network I/O.

## Tests
- New `test_scheduler.py` (active-entry, transition window incl. midnight wrap, reapply-on-load vs. no-reapply-on-set, clear, persistence round-trip) and `/schedule` endpoint tests in `test_main.py`. All 16 lightbar tests pass.

## Deploy note
The device-side scheduler is **inert until the lightbar image is redeployed to every active Pi** (`rsync` + `docker compose pull && restart`, per the README).