### PR TITLE
feat: throttle transient PlantGrowthChamber connection warnings

### DIFF
--- a/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
+++ b/src/environments/PlantGrowthChamber/PlantGrowthChamber.py
@@ -7,6 +7,32 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+
+class ConnectionIssueTracker:
+    """Suppress transient connection warnings; send one alert after 4 consecutive minutes of failures."""
+
+    ALERT_THRESHOLD = timedelta(minutes=4)
+
+    def __init__(self):
+        self._first_failure: datetime | None = None
+        self._alert_sent = False
+
+    def record_failure(self, now: datetime) -> bool:
+        """Return True the first time the failure window crosses ALERT_THRESHOLD."""
+        if self._first_failure is None:
+            self._first_failure = now
+        if not self._alert_sent and (now - self._first_failure) >= self.ALERT_THRESHOLD:
+            self._alert_sent = True
+            return True
+        return False
+
+    def record_success(self) -> bool:
+        """Return True if an alert was previously sent (connectivity now resolved)."""
+        was_alerted = self._alert_sent
+        self._first_failure = None
+        self._alert_sent = False
+        return was_alerted
+
 import numpy as np
 from PIL import Image
 
@@ -95,6 +121,10 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
 
         self.df = pd.DataFrame()
 
+        self._camera_trackers: dict[str, ConnectionIssueTracker] = {}
+        self._lightbar_tracker = ConnectionIssueTracker()
+        self._lan_tracker = ConnectionIssueTracker()
+
     async def _ensure_action_session(self):
         """RetryClient for lightbar PUT."""
         if self.action_session is None:
@@ -137,16 +167,30 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
 
     async def _get_observation_inner(self):
         # Cameras and power run in parallel under one LAN budget; CV runs after.
+        lan_ok = True
         try:
             await asyncio.wait_for(
                 asyncio.gather(self.get_image(), self.get_power()),
                 timeout=LAN_BUDGET_S,
             )
         except Exception:
-            logger.warning(
-                "LAN observation (cameras + power) exceeded %ss budget",
-                LAN_BUDGET_S,
-                exc_info=True,
+            lan_ok = False
+            now = self.get_time()
+            if self._lan_tracker.record_failure(now):
+                logger.warning(
+                    "LAN observation (cameras + power) exceeded %ss budget",
+                    LAN_BUDGET_S,
+                    exc_info=True,
+                )
+            else:
+                logger.debug(
+                    "Transient: LAN observation exceeded %ss budget",
+                    LAN_BUDGET_S,
+                    exc_info=True,
+                )
+        if lan_ok and self._lan_tracker.record_success():
+            logger.info(
+                "LAN observation (cameras + power) connectivity restored after sustained outage"
             )
         if "left" in self.images and "right" in self.images:
             self.image = np.hstack(
@@ -296,15 +340,26 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             await asyncio.gather(*tasks)
 
     async def _fetch_image(self, session, url, side):
+        tracker = self._camera_trackers.setdefault(side, ConnectionIssueTracker())
         try:
             async with session.get(url) as response:
                 image_data = await response.read()
                 self.images[side] = Image.open(io.BytesIO(image_data))
                 logger.debug(f"Successfully fetched image from {url}")
+                if tracker.record_success():
+                    logger.info(
+                        f"Camera {side} ({url}) connectivity restored after sustained outage"
+                    )
         except Exception:
-            logger.warning(
-                f"Warning: {url} after retries, re-using previous image", exc_info=True
-            )
+            now = self.get_time()
+            if tracker.record_failure(now):
+                logger.warning(
+                    f"Warning: {url} after retries, re-using previous image", exc_info=True
+                )
+            else:
+                logger.debug(
+                    f"Transient: {url} failed, re-using previous image", exc_info=True
+                )
 
     async def put_action(self, action):
         """Send action to the lightbar using aiohttp."""
@@ -330,16 +385,34 @@ class PlantGrowthChamber(BaseAsyncEnvironment):
             )
             self.last_action = action
             self.last_calibrated_action = last_calibrated_action
+            if self._lightbar_tracker.record_success():
+                logger.info(
+                    f"Lightbar ({self.zone.lightbar_url}) connectivity restored after sustained outage"
+                )
         except Exception:
+            now = self.get_time()
+            should_alert = self._lightbar_tracker.record_failure(now)
             if not np.array_equal(action, self.last_action):
-                logger.exception(
-                    f"Error: {self.zone.lightbar_url} after retries, re-using last action: {self.last_action}"
-                )
+                if should_alert:
+                    logger.exception(
+                        f"Error: {self.zone.lightbar_url} after retries, re-using last action: {self.last_action}"
+                    )
+                else:
+                    logger.debug(
+                        f"Transient: {self.zone.lightbar_url} failed, re-using last action: {self.last_action}",
+                        exc_info=True,
+                    )
             else:
-                logger.warning(
-                    f"Warning: {self.zone.lightbar_url} after retries, last action was identical",
-                    exc_info=True,
-                )
+                if should_alert:
+                    logger.warning(
+                        f"Warning: {self.zone.lightbar_url} after retries, last action was identical",
+                        exc_info=True,
+                    )
+                else:
+                    logger.debug(
+                        f"Transient: {self.zone.lightbar_url} failed, last action was identical",
+                        exc_info=True,
+                    )
 
     async def start(self):
         logger.debug(f"Local time: {self.get_local_time()}. Step 0")

--- a/tests/environments/PlantGrowthChamber/test_ConnectionIssueTracker.py
+++ b/tests/environments/PlantGrowthChamber/test_ConnectionIssueTracker.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from environments.PlantGrowthChamber.PlantGrowthChamber import ConnectionIssueTracker
+
+UTC = ZoneInfo("Etc/UTC")
+
+
+def t(minute: int) -> datetime:
+    return datetime(2024, 1, 1, 0, minute, 0, tzinfo=UTC)
+
+
+class TestConnectionIssueTracker:
+    def test_no_alert_before_threshold(self):
+        tracker = ConnectionIssueTracker()
+        # 3 consecutive failures (0, 1, 2 minutes) — below 4-minute threshold
+        assert tracker.record_failure(t(0)) is False
+        assert tracker.record_failure(t(1)) is False
+        assert tracker.record_failure(t(2)) is False
+
+    def test_alert_fires_at_threshold(self):
+        tracker = ConnectionIssueTracker()
+        assert tracker.record_failure(t(0)) is False
+        assert tracker.record_failure(t(1)) is False
+        assert tracker.record_failure(t(2)) is False
+        # 4th minute crosses the 4-minute window → alert
+        assert tracker.record_failure(t(4)) is True
+
+    def test_alert_fires_only_once(self):
+        tracker = ConnectionIssueTracker()
+        tracker.record_failure(t(0))
+        tracker.record_failure(t(4))  # alert fires here
+        # subsequent failures do not re-alert
+        assert tracker.record_failure(t(5)) is False
+        assert tracker.record_failure(t(6)) is False
+
+    def test_no_resolution_without_prior_alert(self):
+        tracker = ConnectionIssueTracker()
+        tracker.record_failure(t(0))
+        tracker.record_failure(t(1))
+        # less than threshold — no alert was sent
+        assert tracker.record_success() is False
+
+    def test_resolution_after_alert(self):
+        tracker = ConnectionIssueTracker()
+        tracker.record_failure(t(0))
+        tracker.record_failure(t(4))  # alert fires
+        assert tracker.record_success() is True
+
+    def test_resolution_resets_tracker(self):
+        tracker = ConnectionIssueTracker()
+        tracker.record_failure(t(0))
+        tracker.record_failure(t(4))
+        tracker.record_success()
+        # After resolution, a new 3-minute window should not alert
+        assert tracker.record_failure(t(10)) is False
+        assert tracker.record_failure(t(11)) is False
+        assert tracker.record_failure(t(12)) is False
+
+    def test_resolution_then_new_alert_cycle(self):
+        tracker = ConnectionIssueTracker()
+        tracker.record_failure(t(0))
+        tracker.record_failure(t(4))
+        tracker.record_success()
+        # New failure window starts fresh
+        assert tracker.record_failure(t(10)) is False
+        assert tracker.record_failure(t(14)) is True
+
+    def test_success_without_any_failure(self):
+        tracker = ConnectionIssueTracker()
+        assert tracker.record_success() is False
+
+    def test_consecutive_successes_do_not_raise(self):
+        tracker = ConnectionIssueTracker()
+        assert tracker.record_success() is False
+        assert tracker.record_success() is False
+
+    def test_exact_threshold_boundary(self):
+        tracker = ConnectionIssueTracker()
+        tracker.record_failure(t(0))
+        # Exactly at 4 minutes (t(0) + 4 min = t(4))
+        assert tracker.record_failure(t(4)) is True
+
+    def test_just_under_threshold(self):
+        tracker = ConnectionIssueTracker()
+        tracker.record_failure(t(0))
+        # 3 minutes 59 seconds — just under threshold
+        just_under = datetime(2024, 1, 1, 0, 3, 59, tzinfo=UTC)
+        assert tracker.record_failure(just_under) is False


### PR DESCRIPTION
Closes #362

## Summary

- Adds `ConnectionIssueTracker` to `PlantGrowthChamber.py` — a small state machine that tracks consecutive connection failures per endpoint
- Transient failures (< 4 consecutive minutes) are demoted from `WARNING` to `DEBUG`, suppressing WandB/Slack alerts for known nightly blips
- Once an endpoint has been failing for ≥ 4 minutes, a single `WARNING`/`ERROR` alert fires (same message as before)
- When connectivity is restored after a sustained outage, an `INFO` alert fires noting resolution
- Three tracker instances: `_camera_trackers` (per side), `_lightbar_tracker`, `_lan_tracker`

## Test plan

- [ ] 11 unit tests in `tests/environments/PlantGrowthChamber/test_ConnectionIssueTracker.py` cover:
  - No alert before 4-minute threshold
  - Alert fires exactly at threshold (and only once per outage)
  - Resolution returns True only if alert was previously sent
  - Tracker resets properly after resolution (new failure window starts fresh)
  - Exact boundary and just-under-boundary cases
- [ ] `uv run pytest tests/environments/PlantGrowthChamber/test_ConnectionIssueTracker.py` — all 11 pass